### PR TITLE
Robustness/UX quick-wins: error boundary, toasts, accessibility

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -1,13 +1,16 @@
 import { RootProvider } from "./context/RootContext";
+import ErrorBoundary from "./components/utils/ErrorBoundary";
 import AppRouter from "./Router"
 
 
 function App() {
 
     return (
-        <RootProvider>
-            <AppRouter />
-        </RootProvider>
+        <ErrorBoundary>
+            <RootProvider>
+                <AppRouter />
+            </RootProvider>
+        </ErrorBoundary>
     )
 }
 

--- a/app/src/components/adminComponents/GroupDetailModal.jsx
+++ b/app/src/components/adminComponents/GroupDetailModal.jsx
@@ -179,7 +179,7 @@ export default function GroupDetailModal({ open, onClose, group, users, printers
                                 disableGutters
                                 secondaryAction={
                                     <Tooltip title="Remove from group">
-                                        <IconButton size="small" color="error" onClick={() => handleRemoveMember(u.id)}>
+                                        <IconButton size="small" color="error" onClick={() => handleRemoveMember(u.id)} aria-label="Remove from group">
                                             <DeleteIcon fontSize="small" />
                                         </IconButton>
                                     </Tooltip>
@@ -237,12 +237,12 @@ export default function GroupDetailModal({ open, onClose, group, users, printers
                                         isEditing ? (
                                             <Stack direction="row" spacing={0.5}>
                                                 <Tooltip title="Save">
-                                                    <IconButton size="small" color="success" onClick={() => handleUpdatePermit(permit.printer_id)}>
+                                                    <IconButton size="small" color="success" onClick={() => handleUpdatePermit(permit.printer_id)} aria-label="Save">
                                                         <CheckIcon fontSize="small" />
                                                     </IconButton>
                                                 </Tooltip>
                                                 <Tooltip title="Cancel">
-                                                    <IconButton size="small" onClick={() => setEditingPermit(null)}>
+                                                    <IconButton size="small" onClick={() => setEditingPermit(null)} aria-label="Cancel">
                                                         <CloseIcon fontSize="small" />
                                                     </IconButton>
                                                 </Tooltip>
@@ -254,12 +254,12 @@ export default function GroupDetailModal({ open, onClose, group, users, printers
                                                         printerId: permit.printer_id,
                                                         bw: permit.custom_price_bw ?? "",
                                                         color: permit.custom_price_color ?? "",
-                                                    })}>
+                                                    })} aria-label="Edit prices">
                                                         <EditIcon fontSize="small" />
                                                     </IconButton>
                                                 </Tooltip>
                                                 <Tooltip title="Remove permit">
-                                                    <IconButton size="small" color="error" onClick={() => handleRemovePermit(permit.printer_id)}>
+                                                    <IconButton size="small" color="error" onClick={() => handleRemovePermit(permit.printer_id)} aria-label="Remove permit">
                                                         <DeleteIcon fontSize="small" />
                                                     </IconButton>
                                                 </Tooltip>

--- a/app/src/components/adminComponents/PrinterStatusGrid.jsx
+++ b/app/src/components/adminComponents/PrinterStatusGrid.jsx
@@ -225,14 +225,14 @@ function PrinterCard({ printer, onEdit, onDelete }) {
                         <Box display="flex" gap={0.5} alignItems="center">
                             {onEdit && (
                                 <Tooltip title="Edit printer">
-                                    <IconButton size="small" onClick={() => onEdit(printer)}>
+                                    <IconButton size="small" onClick={() => onEdit(printer)} aria-label="Edit printer">
                                         <SettingsIcon fontSize="small" />
                                     </IconButton>
                                 </Tooltip>
                             )}
                             {onDelete && (
                                 <Tooltip title="Delete printer">
-                                    <IconButton size="small" color="error" onClick={() => onDelete(printer)}>
+                                    <IconButton size="small" color="error" onClick={() => onDelete(printer)} aria-label="Delete printer">
                                         <DeleteIcon fontSize="small" />
                                     </IconButton>
                                 </Tooltip>

--- a/app/src/components/adminSettings/ADConfigSection.jsx
+++ b/app/src/components/adminSettings/ADConfigSection.jsx
@@ -37,6 +37,7 @@ export default function ADConfigSection() {
             const { silent, ...payload } = variables;
             return updateADConfig(payload);
         },
+        meta: { skipGlobalErrorToast: true },
         onSuccess: (_data, variables) => {
             queryClient.invalidateQueries(["admin-ad-config"]);
             if (!variables?.silent) {
@@ -50,6 +51,7 @@ export default function ADConfigSection() {
     });
     const importMutation = useMutation({
         mutationFn: importADUsers,
+        meta: { skipGlobalErrorToast: true },
         onSuccess: (result) => {
             queryClient.invalidateQueries(["admin-users"]);
             setImportModalOpen(false);
@@ -66,6 +68,7 @@ export default function ADConfigSection() {
     });
     const previewMutation = useMutation({
         mutationFn: previewADUsersImport,
+        meta: { skipGlobalErrorToast: true },
         onSuccess: (result) => {
             setPreviewResult(result);
         },

--- a/app/src/components/adminSettings/RechargeInfoSection.jsx
+++ b/app/src/components/adminSettings/RechargeInfoSection.jsx
@@ -34,6 +34,7 @@ export default function RechargeInfoSection() {
     }, [data]);
     const saveMutation = useMutation({
         mutationFn: updateRechargeInfo,
+        meta: { skipGlobalErrorToast: true },
         onSuccess: () => {
             queryClient.invalidateQueries(["admin-recharge-info"]);
             enqueueSnackbar("Recharge info saved.", { variant: "success" });
@@ -167,6 +168,7 @@ export default function RechargeInfoSection() {
                                             color="error"
                                             onClick={() => removeContact(i)}
                                             sx={{ alignSelf: { xs: "flex-end", md: "center" } }}
+                                            aria-label="Remove contact"
                                         >
                                             <DeleteIcon fontSize="small" />
                                         </IconButton>

--- a/app/src/components/adminSettings/TelegramAdminsSection.jsx
+++ b/app/src/components/adminSettings/TelegramAdminsSection.jsx
@@ -22,6 +22,7 @@ export default function TelegramAdminsSection() {
     const [addError, setAddError] = useState("");
     const addMutation = useMutation({
         mutationFn: ({ username, telegram_id }) => addTelegramAdmin(username, telegram_id),
+        meta: { skipGlobalErrorToast: true },
         onSuccess: () => {
             queryClient.invalidateQueries(["admin-telegram-admins"]);
             setNewUsername("");
@@ -36,6 +37,7 @@ export default function TelegramAdminsSection() {
     });
     const removeMutation = useMutation({
         mutationFn: removeTelegramAdmin,
+        meta: { skipGlobalErrorToast: true },
         onSuccess: () => {
             queryClient.invalidateQueries(["admin-telegram-admins"]);
             enqueueSnackbar("Telegram admin removed.", { variant: "success" });
@@ -114,6 +116,7 @@ export default function TelegramAdminsSection() {
                                                 onClick={() => removeMutation.mutate(ta.id)}
                                                 disabled={removeMutation.isPending}
                                                 sx={{ alignSelf: { xs: "flex-end", sm: "center" } }}
+                                                aria-label="Remove telegram admin"
                                             >
                                                 <DeleteIcon fontSize="small" />
                                             </IconButton>

--- a/app/src/components/adminSettings/TonerAlertSection.jsx
+++ b/app/src/components/adminSettings/TonerAlertSection.jsx
@@ -29,6 +29,7 @@ export default function TonerAlertSection() {
     }, [data]);
     const saveMutation = useMutation({
         mutationFn: (payload) => updateTonerAlertConfig(payload),
+        meta: { skipGlobalErrorToast: true },
         onSuccess: () => {
             queryClient.invalidateQueries(["admin-toner-alert"]);
             enqueueSnackbar("Toner alert settings saved.", { variant: "success" });

--- a/app/src/components/balanceComponents/BalanceHeader.jsx
+++ b/app/src/components/balanceComponents/BalanceHeader.jsx
@@ -3,7 +3,7 @@ import { Box, Typography } from "@mui/material";
 import LoadingTypography from "../utils/LoadingTypography";
 import UserPageHero from "../userViewComponents/UserPageHero";
 
-export default function BalanceHeader({ user, isLoading }) {
+export default function BalanceHeader({ user, isLoading, isError }) {
 
     return (
         <UserPageHero
@@ -14,15 +14,21 @@ export default function BalanceHeader({ user, isLoading }) {
                 <Typography variant="caption" color="text.secondary">
                     Available balance
                 </Typography>
-                <LoadingTypography
-                    isLoading={isLoading}
-                    variant="h5"
-                    color="primary.main"
-                    loadingWidth={80}
-                    sx={{ fontWeight: 700 }}
-                >
-                    €{user?.balance?.toFixed(2)}
-                </LoadingTypography>
+                {isError ? (
+                    <Typography variant="h5" color="error.main" sx={{ fontWeight: 700 }}>
+                        Unavailable
+                    </Typography>
+                ) : (
+                    <LoadingTypography
+                        isLoading={isLoading}
+                        variant="h5"
+                        color="primary.main"
+                        loadingWidth={80}
+                        sx={{ fontWeight: 700 }}
+                    >
+                        €{user?.balance?.toFixed(2)}
+                    </LoadingTypography>
+                )}
             </Box>
         </UserPageHero>
     );

--- a/app/src/components/mainViewComponents/TopBar.jsx
+++ b/app/src/components/mainViewComponents/TopBar.jsx
@@ -110,8 +110,8 @@ export default function TopBar({ onMenuClick, isDesktop }) {
                 const info = await getAppInfo();
                 setAppName(info.app);
                 setAppVersion(info.version);
-            } catch (err) {
-                console.error("Failed to fetch app info:", err);
+            } catch {
+                // Non-critical (version string in the UI) — quietly keep the defaults.
             } finally {
                 setLoadingAppInfo(false);
             }
@@ -134,6 +134,7 @@ export default function TopBar({ onMenuClick, isDesktop }) {
                         edge="start"
                         onClick={onMenuClick}
                         sx={{ mr: 2 }}
+                        aria-label="Open menu"
                     >
                         <MenuIcon />
                     </IconButton>
@@ -151,7 +152,7 @@ export default function TopBar({ onMenuClick, isDesktop }) {
 
                 <Box sx={{ display: "flex", alignItems: "center" }}>
                     <Tooltip title="Account settings">
-                        <IconButton onClick={handleMenuOpen} sx={{ p: 0 }}>
+                        <IconButton onClick={handleMenuOpen} sx={{ p: 0 }} aria-label="Account settings">
                             <Avatar sx={{ bgcolor: "secondary.main" }}>
                                 { (isLoading || isError)? (
                                     <CircularProgress color="inherit" size={20}/>

--- a/app/src/components/printComponents/PrintOptionsForm.jsx
+++ b/app/src/components/printComponents/PrintOptionsForm.jsx
@@ -123,7 +123,7 @@ export default function PrintOptionsForm({ options, onChange, colorDisabled, dup
                 </FormControl>
                 {duplexDisabled && (
                     <Tooltip title="This printer does not support automatic 2-sided (duplex) printing." arrow>
-                        <IconButton size="small" tabIndex={-1} sx={{ flexShrink: 0 }}>
+                        <IconButton size="small" tabIndex={-1} sx={{ flexShrink: 0 }} aria-label="Duplex unavailable info">
                             <InfoOutlinedIcon fontSize="small" color="disabled" />
                         </IconButton>
                     </Tooltip>

--- a/app/src/components/utils/ErrorBoundary.jsx
+++ b/app/src/components/utils/ErrorBoundary.jsx
@@ -1,0 +1,45 @@
+import { Component } from "react";
+import { Box, Button, Stack, Typography } from "@mui/material";
+
+export default class ErrorBoundary extends Component {
+    constructor(props) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError() {
+        return { hasError: true };
+    }
+
+    componentDidCatch(error, info) {
+        console.error("Uncaught render error:", error, info);
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return (
+                <Box
+                    sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        minHeight: "100vh",
+                        p: 3,
+                    }}
+                >
+                    <Stack spacing={2} alignItems="center" textAlign="center">
+                        <Typography variant="h5">Something went wrong</Typography>
+                        <Typography variant="body2" color="text.secondary">
+                            An unexpected error occurred. Try reloading the page.
+                        </Typography>
+                        <Button variant="contained" onClick={() => window.location.reload()}>
+                            Reload
+                        </Button>
+                    </Stack>
+                </Box>
+            );
+        }
+
+        return this.props.children;
+    }
+}

--- a/app/src/context/QueryContext.jsx
+++ b/app/src/context/QueryContext.jsx
@@ -1,8 +1,30 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClient, QueryCache, MutationCache, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { enqueueSnackbar } from 'notistack'
 
 
-const queryClient = new QueryClient();
+function reportError(error, query) {
+    // 401s are already handled by the auth-expired redirect flow; a toast
+    // on top of that is just noise. Callers that already show their own
+    // error UI can opt out via `meta: { skipGlobalErrorToast: true }`.
+    if (error?.response?.status === 401) return;
+    if (query?.meta?.skipGlobalErrorToast || query?.options?.meta?.skipGlobalErrorToast) return;
+
+    const message = !error?.response
+        ? "Network error — check your connection"
+        : error.response.data?.detail || "Something went wrong";
+
+    enqueueSnackbar(message, { variant: "error" });
+}
+
+const queryClient = new QueryClient({
+    queryCache: new QueryCache({
+        onError: (error, query) => reportError(error, query),
+    }),
+    mutationCache: new MutationCache({
+        onError: (error, _variables, _context, mutation) => reportError(error, mutation),
+    }),
+});
 
 
 export function QueryContext({ children }) {

--- a/app/src/services/api.js
+++ b/app/src/services/api.js
@@ -40,17 +40,6 @@ api.interceptors.response.use(
 );
 
 
-api.interceptors.response.use(
-    res => res,
-    err => {
-        if (!err.response && err.request) {
-            if (typeof authExpiredCallback === 'function') authExpiredCallback();
-        }
-        return Promise.reject(err);
-    }
-);
-
-
 // Several endpoints enforce a server-side page size (default 50, max 200)
 // and return a plain list with no "has more" indicator. Callers that need
 // the full collection (there's no pagination UI in this app) loop pages

--- a/app/src/views/AdminActivityPage.jsx
+++ b/app/src/views/AdminActivityPage.jsx
@@ -227,7 +227,7 @@ export default function AdminActivityPage() {
                             ),
                             endAdornment: search ? (
                                 <InputAdornment position="end">
-                                    <IconButton size="small" onClick={() => setSearch("")}>
+                                    <IconButton size="small" onClick={() => setSearch("")} aria-label="Clear search">
                                         <ClearIcon fontSize="small" />
                                     </IconButton>
                                 </InputAdornment>

--- a/app/src/views/AdminGroupsPage.jsx
+++ b/app/src/views/AdminGroupsPage.jsx
@@ -174,12 +174,12 @@ export default function AdminGroupsPage() {
                                     <TableCell align="center">
                                         <Stack direction="row" justifyContent="center" spacing={0.5}>
                                             <Tooltip title="Manage members & permits">
-                                                <IconButton size="small" onClick={() => setDetailGroup(group)}>
+                                                <IconButton size="small" onClick={() => setDetailGroup(group)} aria-label="Manage members & permits">
                                                     <EditIcon fontSize="small" />
                                                 </IconButton>
                                             </Tooltip>
                                             <Tooltip title="Delete group">
-                                                <IconButton size="small" color="error" onClick={() => handleDelete(group)}>
+                                                <IconButton size="small" color="error" onClick={() => handleDelete(group)} aria-label="Delete group">
                                                     <DeleteIcon fontSize="small" />
                                                 </IconButton>
                                             </Tooltip>

--- a/app/src/views/AdminRefundsPage.jsx
+++ b/app/src/views/AdminRefundsPage.jsx
@@ -215,7 +215,7 @@ export default function AdminRefundsPage() {
                                     <TableCell align="right">
                                         {refund.status === "pending" && (
                                             <Tooltip title="Resolve request">
-                                                <IconButton size="small" onClick={(e) => { e.stopPropagation(); openModal(); }}>
+                                                <IconButton size="small" onClick={(e) => { e.stopPropagation(); openModal(); }} aria-label="Resolve request">
                                                     <GavelIcon fontSize="small" />
                                                 </IconButton>
                                             </Tooltip>

--- a/app/src/views/AdminUsersPage.jsx
+++ b/app/src/views/AdminUsersPage.jsx
@@ -144,7 +144,7 @@ export default function AdminUsersPage() {
                             ),
                             endAdornment: search ? (
                                 <InputAdornment position="end">
-                                    <IconButton size="small" onClick={() => setSearch("")}>
+                                    <IconButton size="small" onClick={() => setSearch("")} aria-label="Clear search">
                                         <ClearIcon fontSize="small" />
                                     </IconButton>
                                 </InputAdornment>
@@ -270,22 +270,22 @@ export default function AdminUsersPage() {
                                     </TableCell>
                                     <TableCell align="right">
                                         <Tooltip title="Edit user info">
-                                            <IconButton size="small" onClick={(e) => { e.stopPropagation(); setEditUser(user); }}>
+                                            <IconButton size="small" onClick={(e) => { e.stopPropagation(); setEditUser(user); }} aria-label="Edit user info">
                                                 <EditIcon fontSize="small" />
                                             </IconButton>
                                         </Tooltip>
                                         <Tooltip title="Adjust balance">
-                                            <IconButton size="small" onClick={(e) => { e.stopPropagation(); setRechargeUser(user); }}>
+                                            <IconButton size="small" onClick={(e) => { e.stopPropagation(); setRechargeUser(user); }} aria-label="Adjust balance">
                                                 <AccountBalanceWalletIcon fontSize="small" />
                                             </IconButton>
                                         </Tooltip>
                                         <Tooltip title="View transactions">
-                                            <IconButton size="small" onClick={(e) => { e.stopPropagation(); setTxUser(user); }}>
+                                            <IconButton size="small" onClick={(e) => { e.stopPropagation(); setTxUser(user); }} aria-label="View transactions">
                                                 <ReceiptLongIcon fontSize="small" />
                                             </IconButton>
                                         </Tooltip>
                                         <Tooltip title="Delete user">
-                                            <IconButton size="small" color="error" onClick={(e) => { e.stopPropagation(); setConfirmDeleteUser(user); }}>
+                                            <IconButton size="small" color="error" onClick={(e) => { e.stopPropagation(); setConfirmDeleteUser(user); }} aria-label="Delete user">
                                                 <DeleteIcon fontSize="small" />
                                             </IconButton>
                                         </Tooltip>
@@ -314,6 +314,7 @@ export default function AdminUsersPage() {
                         onClick={() => setSelectedUser(null)}
                         size="small"
                         sx={{ position: "absolute", top: 8, right: 8 }}
+                        aria-label="Close"
                     >
                         <CloseIcon fontSize="small" />
                     </IconButton>

--- a/app/src/views/BalancePage.jsx
+++ b/app/src/views/BalancePage.jsx
@@ -17,7 +17,8 @@ export default function BalancePage() {
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2.25 }}>
         <BalanceHeader
             user={user}
-            isLoading={isLoadingUser || isErrorUser}
+            isLoading={isLoadingUser}
+            isError={isErrorUser}
         />
 
         <UserSurface title="Recharge Options" description="See the available ways to add credit to your account.">

--- a/app/src/views/HistoryPage.jsx
+++ b/app/src/views/HistoryPage.jsx
@@ -158,6 +158,7 @@ export default function HistoryPage() {
                                                         size="small"
                                                         color="warning"
                                                         onClick={(e) => { e.stopPropagation(); setRefundJob(job); }}
+                                                        aria-label="Re-submit refund request"
                                                     >
                                                         <ReplayIcon fontSize="small" />
                                                     </IconButton>
@@ -170,6 +171,7 @@ export default function HistoryPage() {
                                                     size="small"
                                                     color="warning"
                                                     onClick={(e) => { e.stopPropagation(); setRefundJob(job); }}
+                                                    aria-label="Request refund"
                                                 >
                                                     <ReplayIcon fontSize="small" />
                                                 </IconButton>

--- a/app/src/views/LoginPage.jsx
+++ b/app/src/views/LoginPage.jsx
@@ -69,6 +69,7 @@ export default function LoginPage() {
                 color="primary"
                 sx={{ position: "absolute", top: 8, right: 8 }}
                 onClick={() => setHelpOpen(true)}
+                aria-label="Help"
             >
                 <HelpOutlineIcon />
             </IconButton>

--- a/app/src/views/PwdRequestPage.jsx
+++ b/app/src/views/PwdRequestPage.jsx
@@ -70,6 +70,7 @@ export default function PwdRequestPage() {
                 color="primary"
                 sx={{ position: "absolute", top: 8, right: 8 }}
                 onClick={() => setHelpOpen(true)}
+                aria-label="Help"
             >
                 <HelpOutlineIcon />
             </IconButton>
@@ -79,6 +80,7 @@ export default function PwdRequestPage() {
                 color="primary"
                 sx={{ position: "absolute", top: 8, left: 8 }}
                 onClick={() => navigate(-1)}
+                aria-label="Go back"
             >
                 <ArrowBackIcon />
             </IconButton>

--- a/app/src/views/PwdResetPage.jsx
+++ b/app/src/views/PwdResetPage.jsx
@@ -79,6 +79,7 @@ export default function PwdResetPage() {
                             color="primary"
                             sx={{ position: "absolute", top: 8, right: 8 }}
                             onClick={() => setHelpOpen(true)}
+                            aria-label="Help"
                         >
                             <HelpOutlineIcon />
                         </IconButton>


### PR DESCRIPTION
## Summary
- Top-level Error Boundary — an uncaught render error now shows a friendly reload screen instead of a white screen.
- Fixed `BalancePage` rendering an API error as an infinite spinner (loading/error states were conflated).
- Stopped treating network errors the same as session expiry — only a real 401 forces logout now (previously any request with no response, including a transient network blip, triggered a forced logout).
- Added a global `QueryCache`/`MutationCache` error handler that toasts unhandled query/mutation failures (most call sites were previously silent on error); existing call sites with bespoke error handling opt out via `meta: { skipGlobalErrorToast: true }` to avoid double-toasting.
- Added `aria-label`s to every icon-only button app-wide (previously zero).
- Removed the last silent `console.error` (app-info fetch failure) in favor of a quiet fallback.

Backlogged for a future pass (flagged, not fixed here — larger refactors, out of scope for this quick-wins pass):
- 4 oversized components (`AdminStatisticsPage.jsx` 657 lines, `StepSend.jsx` 597, `AdminUsersPage.jsx` 418, `GroupDetailModal.jsx` 399) — real maintainability debt, but splitting them is structural work, not a quick win.

## Test plan
- [x] `npm run lint` — 0 errors (pre-existing warnings unrelated to this change)
- [x] `npm run test` — 18/18 passing
- [x] `npm run build` — succeeds
- [ ] Manual: force a render error and confirm the Error Boundary catches it
- [ ] Manual: stop the backend and confirm a toast appears instead of a forced logout