### PR TITLE
Backlog cleanup: split 4 oversized components + regression tests

### DIFF
--- a/app/src/components/adminComponents/ConfirmDeleteUserDialog.jsx
+++ b/app/src/components/adminComponents/ConfirmDeleteUserDialog.jsx
@@ -1,0 +1,26 @@
+import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from "@mui/material";
+
+export default function ConfirmDeleteUserDialog({ user, onClose, onConfirm }) {
+    return (
+        <Dialog
+            open={Boolean(user)}
+            onClose={onClose}
+            maxWidth="xs"
+            fullWidth
+        >
+            <DialogTitle>Delete user?</DialogTitle>
+            <DialogContent>
+                <DialogContentText>
+                    Are you sure you want to permanently delete{" "}
+                    <strong>{user?.username}</strong>? This action cannot be undone.
+                </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose}>Cancel</Button>
+                <Button color="error" variant="contained" onClick={onConfirm}>
+                    Delete
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+}

--- a/app/src/components/adminComponents/FinanceBreakdownItem.jsx
+++ b/app/src/components/adminComponents/FinanceBreakdownItem.jsx
@@ -1,0 +1,47 @@
+import { Box, Skeleton, Stack, Typography } from "@mui/material";
+
+export default function FinanceBreakdownItem({ icon, label, value, color, subtitle, loading }) {
+    return (
+        <Box
+            sx={{
+                p: { xs: 1.5, sm: 2 },
+                borderRadius: 2,
+                border: "1px solid",
+                borderColor: "divider",
+                flex: 1,
+                minWidth: 0,
+            }}
+        >
+            <Stack direction="row" alignItems="center" spacing={0.7} mb={0.5}>
+                <Box sx={{ color, display: "flex", alignItems: "center", flexShrink: 0 }}>{icon}</Box>
+                <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ fontSize: { xs: "0.7rem", sm: "0.8rem" }, lineHeight: 1.3 }}
+                >
+                    {label}
+                </Typography>
+            </Stack>
+            {loading ? (
+                <Skeleton width="65%" height={26} />
+            ) : (
+                <Typography
+                    fontWeight="bold"
+                    color={color}
+                    sx={{ fontSize: { xs: "1rem", sm: "1.3rem" } }}
+                >
+                    {value}
+                </Typography>
+            )}
+            {subtitle && (
+                <Typography
+                    variant="caption"
+                    color="text.disabled"
+                    sx={{ display: { xs: "none", sm: "block" } }}
+                >
+                    {subtitle}
+                </Typography>
+            )}
+        </Box>
+    );
+}

--- a/app/src/components/adminComponents/GroupDetailModal.jsx
+++ b/app/src/components/adminComponents/GroupDetailModal.jsx
@@ -1,42 +1,11 @@
 import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-    Autocomplete,
-    Box,
-    Button,
-    Chip,
-    CircularProgress,
-    Divider,
-    IconButton,
-    InputAdornment,
-    List,
-    ListItem,
-    ListItemText,
-    Stack,
-    Tab,
-    Tabs,
-    TextField,
-    Tooltip,
-    Typography,
-} from "@mui/material";
-import DeleteIcon from "@mui/icons-material/Delete";
-import EditIcon from "@mui/icons-material/Edit";
-import CheckIcon from "@mui/icons-material/Check";
-import CloseIcon from "@mui/icons-material/Close";
-import PersonIcon from "@mui/icons-material/Person";
-import PrintIcon from "@mui/icons-material/Print";
-import LockIcon from "@mui/icons-material/Lock";
-import { useSnackbar } from "notistack";
+import { Box, Button, CircularProgress, Tab, Tabs, Typography } from "@mui/material";
 
 import CustomModal from "../utils/CustomModal";
-import {
-    getGroupDetail,
-    addGroupMember,
-    removeGroupMember,
-    addGroupPrinterPermit,
-    updateGroupPrinterPermit,
-    removeGroupPrinterPermit,
-} from "../../api/group";
+import { getGroupDetail } from "../../api/group";
+import GroupMembersTab from "./GroupMembersTab";
+import GroupPrinterPermitsTab from "./GroupPrinterPermitsTab";
 
 
 function TabPanel({ children, value, index }) {
@@ -45,12 +14,10 @@ function TabPanel({ children, value, index }) {
 
 
 export default function GroupDetailModal({ open, onClose, group, users, printers }) {
-    const { enqueueSnackbar } = useSnackbar();
     const queryClient = useQueryClient();
 
     const [tab, setTab] = useState(0);
 
-    // ── Detail fetch ─────────────────────────────────────────────────────────
     const { data: detail, isLoading: detailLoading } = useQuery({
         queryKey: ["group-detail", group?.id],
         queryFn: () => getGroupDetail(group.id),
@@ -60,94 +27,9 @@ export default function GroupDetailModal({ open, onClose, group, users, printers
 
     const refresh = () => queryClient.invalidateQueries(["group-detail", group?.id]);
 
-    // ── Members ──────────────────────────────────────────────────────────────
-    const [addMemberUser, setAddMemberUser] = useState(null);
-    const [memberLoading, setMemberLoading] = useState(false);
+    const memberCount = (detail?.members ?? []).length;
+    const permitCount = (detail?.printer_permits ?? []).length;
 
-    const memberIds = new Set(detail?.members ?? []);
-    const availableUsers = (users ?? []).filter((u) => !memberIds.has(u.id));
-    const memberUsers = (users ?? []).filter((u) => memberIds.has(u.id));
-
-    const handleAddMember = async () => {
-        if (!addMemberUser) return;
-        setMemberLoading(true);
-        try {
-            await addGroupMember(group.id, addMemberUser.id);
-            setAddMemberUser(null);
-            refresh();
-        } catch {
-            enqueueSnackbar("Failed to add member.", { variant: "error" });
-        } finally {
-            setMemberLoading(false);
-        }
-    };
-
-    const handleRemoveMember = async (userId) => {
-        try {
-            await removeGroupMember(group.id, userId);
-            refresh();
-        } catch {
-            enqueueSnackbar("Failed to remove member.", { variant: "error" });
-        }
-    };
-
-    // ── Printer permits ───────────────────────────────────────────────────────
-    const [addPermitPrinter, setAddPermitPrinter] = useState(null);
-    const [addPermitBw, setAddPermitBw] = useState("");
-    const [addPermitColor, setAddPermitColor] = useState("");
-    const [permitLoading, setPermitLoading] = useState(false);
-
-    // Edit state: { printerId, bw, color }
-    const [editingPermit, setEditingPermit] = useState(null);
-
-    const permitPrinterIds = new Set((detail?.printer_permits ?? []).map((p) => p.printer_id));
-    const availablePrinters = (printers ?? []).filter((p) => !permitPrinterIds.has(p.id ?? p.name));
-
-    const printerById = Object.fromEntries((printers ?? []).map((p) => [p.id ?? p.name, p]));
-
-    const handleAddPermit = async () => {
-        if (!addPermitPrinter) return;
-        setPermitLoading(true);
-        try {
-            await addGroupPrinterPermit(group.id, {
-                printer_id: addPermitPrinter.id,
-                custom_price_bw: addPermitBw !== "" ? parseFloat(addPermitBw) : null,
-                custom_price_color: addPermitColor !== "" ? parseFloat(addPermitColor) : null,
-            });
-            setAddPermitPrinter(null);
-            setAddPermitBw("");
-            setAddPermitColor("");
-            refresh();
-        } catch {
-            enqueueSnackbar("Failed to add printer permit.", { variant: "error" });
-        } finally {
-            setPermitLoading(false);
-        }
-    };
-
-    const handleUpdatePermit = async (printerId) => {
-        try {
-            await updateGroupPrinterPermit(group.id, printerId, {
-                custom_price_bw: editingPermit.bw !== "" ? parseFloat(editingPermit.bw) : null,
-                custom_price_color: editingPermit.color !== "" ? parseFloat(editingPermit.color) : null,
-            });
-            setEditingPermit(null);
-            refresh();
-        } catch {
-            enqueueSnackbar("Failed to update permit.", { variant: "error" });
-        }
-    };
-
-    const handleRemovePermit = async (printerId) => {
-        try {
-            await removeGroupPrinterPermit(group.id, printerId);
-            refresh();
-        } catch {
-            enqueueSnackbar("Failed to remove printer permit.", { variant: "error" });
-        }
-    };
-
-    // ── Render ────────────────────────────────────────────────────────────────
     const content = detailLoading ? (
         <Box display="flex" justifyContent="center" py={4}>
             <CircularProgress />
@@ -161,227 +43,16 @@ export default function GroupDetailModal({ open, onClose, group, users, printers
             )}
 
             <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ borderBottom: 1, borderColor: "divider" }}>
-                <Tab label={`Members (${memberIds.size})`} />
-                <Tab label={`Printer Permits (${permitPrinterIds.size})`} />
+                <Tab label={`Members (${memberCount})`} />
+                <Tab label={`Printer Permits (${permitCount})`} />
             </Tabs>
 
-            {/* ── Members tab ── */}
             <TabPanel value={tab} index={0}>
-                {memberUsers.length === 0 ? (
-                    <Typography variant="body2" color="text.secondary" fontStyle="italic" sx={{ mb: 2 }}>
-                        No members yet.
-                    </Typography>
-                ) : (
-                    <List dense disablePadding sx={{ mb: 1 }}>
-                        {memberUsers.map((u) => (
-                            <ListItem
-                                key={u.id}
-                                disableGutters
-                                secondaryAction={
-                                    <Tooltip title="Remove from group">
-                                        <IconButton size="small" color="error" onClick={() => handleRemoveMember(u.id)} aria-label="Remove from group">
-                                            <DeleteIcon fontSize="small" />
-                                        </IconButton>
-                                    </Tooltip>
-                                }
-                            >
-                                <PersonIcon fontSize="small" sx={{ mr: 1, color: "text.secondary" }} />
-                                <ListItemText
-                                    primary={u.username}
-                                    secondary={`${u.name} ${u.surname} · ${u.email}`}
-                                />
-                            </ListItem>
-                        ))}
-                    </List>
-                )}
-                <Divider sx={{ my: 1 }} />
-                <Stack direction="row" spacing={1} alignItems="center">
-                    <Autocomplete
-                        size="small"
-                        options={availableUsers}
-                        getOptionLabel={(u) => `${u.username} — ${u.name} ${u.surname}`}
-                        value={addMemberUser}
-                        onChange={(_, v) => setAddMemberUser(v)}
-                        renderInput={(params) => <TextField {...params} label="Add user" />}
-                        sx={{ flexGrow: 1 }}
-                        isOptionEqualToValue={(o, v) => o.id === v.id}
-                    />
-                    <Button
-                        variant="contained"
-                        size="small"
-                        disabled={!addMemberUser || memberLoading}
-                        onClick={handleAddMember}
-                    >
-                        {memberLoading ? <CircularProgress size={16} /> : "Add"}
-                    </Button>
-                </Stack>
+                <GroupMembersTab group={group} users={users} detail={detail} refresh={refresh} />
             </TabPanel>
 
-            {/* ── Printer permits tab ── */}
             <TabPanel value={tab} index={1}>
-                {(detail?.printer_permits ?? []).length === 0 ? (
-                    <Typography variant="body2" color="text.secondary" fontStyle="italic" sx={{ mb: 2 }}>
-                        No printer permits yet.
-                    </Typography>
-                ) : (
-                    <List dense disablePadding sx={{ mb: 1 }}>
-                        {(detail?.printer_permits ?? []).map((permit) => {
-                            const printer = printerById[permit.printer_id];
-                            const isEditing = editingPermit?.printerId === permit.printer_id;
-                            return (
-                                <ListItem
-                                    key={permit.printer_id}
-                                    disableGutters
-                                    alignItems="flex-start"
-                                    secondaryAction={
-                                        isEditing ? (
-                                            <Stack direction="row" spacing={0.5}>
-                                                <Tooltip title="Save">
-                                                    <IconButton size="small" color="success" onClick={() => handleUpdatePermit(permit.printer_id)} aria-label="Save">
-                                                        <CheckIcon fontSize="small" />
-                                                    </IconButton>
-                                                </Tooltip>
-                                                <Tooltip title="Cancel">
-                                                    <IconButton size="small" onClick={() => setEditingPermit(null)} aria-label="Cancel">
-                                                        <CloseIcon fontSize="small" />
-                                                    </IconButton>
-                                                </Tooltip>
-                                            </Stack>
-                                        ) : (
-                                            <Stack direction="row" spacing={0.5}>
-                                                <Tooltip title="Edit prices">
-                                                    <IconButton size="small" onClick={() => setEditingPermit({
-                                                        printerId: permit.printer_id,
-                                                        bw: permit.custom_price_bw ?? "",
-                                                        color: permit.custom_price_color ?? "",
-                                                    })} aria-label="Edit prices">
-                                                        <EditIcon fontSize="small" />
-                                                    </IconButton>
-                                                </Tooltip>
-                                                <Tooltip title="Remove permit">
-                                                    <IconButton size="small" color="error" onClick={() => handleRemovePermit(permit.printer_id)} aria-label="Remove permit">
-                                                        <DeleteIcon fontSize="small" />
-                                                    </IconButton>
-                                                </Tooltip>
-                                            </Stack>
-                                        )
-                                    }
-                                >
-                                    <PrintIcon fontSize="small" sx={{ mr: 1, mt: 0.5, color: "text.secondary", flexShrink: 0 }} />
-                                    <ListItemText
-                                        primary={
-                                            <Stack direction="row" spacing={1} alignItems="center">
-                                                <Typography variant="body2" fontWeight="medium">
-                                                    {printer?.name ?? permit.printer_id}
-                                                </Typography>
-                                                {printer?.is_restricted && (
-                                                    <Chip icon={<LockIcon />} label="Restricted" size="small" color="warning" variant="outlined" />
-                                                )}
-                                            </Stack>
-                                        }
-                                        secondary={
-                                            isEditing ? (
-                                                <Stack direction="row" spacing={1} sx={{ mt: 0.5 }}>
-                                                    <TextField
-                                                        size="small"
-                                                        label="B&W price"
-                                                        type="number"
-                                                        value={editingPermit.bw}
-                                                        onChange={(e) => setEditingPermit((p) => ({ ...p, bw: e.target.value }))}
-                                                        placeholder="Default"
-                                                        slotProps={{
-                                                            input: {
-                                                                startAdornment: <InputAdornment position="start">€</InputAdornment>,
-                                                                inputProps: { min: 0, step: 0.001 }
-                                                            }
-                                                        }}
-                                                        sx={{ width: 130 }}
-                                                    />
-                                                    <TextField
-                                                        size="small"
-                                                        label="Color price"
-                                                        type="number"
-                                                        value={editingPermit.color}
-                                                        onChange={(e) => setEditingPermit((p) => ({ ...p, color: e.target.value }))}
-                                                        placeholder="Default"
-                                                        disabled={!printer?.admits_color}
-                                                        slotProps={{
-                                                            input: {
-                                                                startAdornment: <InputAdornment position="start">€</InputAdornment>,
-                                                                inputProps: { min: 0, step: 0.001 }
-                                                            }
-                                                        }}
-                                                        sx={{ width: 130 }}
-                                                    />
-                                                </Stack>
-                                            ) : (
-                                                <Typography variant="caption" color="text.secondary">
-                                                    B&W: {permit.custom_price_bw != null ? `€${permit.custom_price_bw.toFixed(3)}` : "Default"}{" · "}
-                                                    Color: {permit.custom_price_color != null ? `€${permit.custom_price_color.toFixed(3)}` : "Default"}
-                                                </Typography>
-                                            )
-                                        }
-                                    />
-                                </ListItem>
-                            );
-                        })}
-                    </List>
-                )}
-                <Divider sx={{ my: 1 }} />
-                <Stack spacing={1}>
-                    <Autocomplete
-                        size="small"
-                        options={availablePrinters}
-                        getOptionLabel={(p) => p.name}
-                        value={addPermitPrinter}
-                        onChange={(_, v) => setAddPermitPrinter(v)}
-                        renderInput={(params) => <TextField {...params} label="Add printer" />}
-                        isOptionEqualToValue={(o, v) => (o.id ?? o.name) === (v.id ?? v.name)}
-                    />
-                    <Stack direction="row" spacing={1} alignItems="center">
-                        <TextField
-                            size="small"
-                            label="Custom B&W price"
-                            type="number"
-                            value={addPermitBw}
-                            onChange={(e) => setAddPermitBw(e.target.value)}
-                            placeholder="Default"
-                            disabled={!addPermitPrinter}
-                            slotProps={{
-                                input: {
-                                    startAdornment: <InputAdornment position="start">€</InputAdornment>,
-                                    inputProps: { min: 0, step: 0.001 }
-                                }
-                            }}
-                            sx={{ flexGrow: 1 }}
-                        />
-                        <TextField
-                            size="small"
-                            label="Custom color price"
-                            type="number"
-                            value={addPermitColor}
-                            onChange={(e) => setAddPermitColor(e.target.value)}
-                            placeholder="Default"
-                            disabled={!addPermitPrinter || !addPermitPrinter?.admits_color}
-                            slotProps={{
-                                input: {
-                                    startAdornment: <InputAdornment position="start">€</InputAdornment>,
-                                    inputProps: { min: 0, step: 0.001 }
-                                }
-                            }}
-                            sx={{ flexGrow: 1 }}
-                        />
-                        <Button
-                            variant="contained"
-                            size="small"
-                            disabled={!addPermitPrinter || permitLoading}
-                            onClick={handleAddPermit}
-                            sx={{ whiteSpace: "nowrap" }}
-                        >
-                            {permitLoading ? <CircularProgress size={16} /> : "Add"}
-                        </Button>
-                    </Stack>
-                </Stack>
+                <GroupPrinterPermitsTab group={group} printers={printers} detail={detail} refresh={refresh} />
             </TabPanel>
         </Box>
     );

--- a/app/src/components/adminComponents/GroupDetailModal.smoke.test.jsx
+++ b/app/src/components/adminComponents/GroupDetailModal.smoke.test.jsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("../../api/group", () => ({
+    getGroupDetail: vi.fn().mockResolvedValue({
+        members: ["u1"],
+        printer_permits: [{ printer_id: "p1", custom_price_bw: null, custom_price_color: null }],
+    }),
+    addGroupMember: vi.fn(),
+    removeGroupMember: vi.fn(),
+    addGroupPrinterPermit: vi.fn(),
+    updateGroupPrinterPermit: vi.fn(),
+    removeGroupPrinterPermit: vi.fn(),
+}));
+
+const { default: GroupDetailModal } = await import("./GroupDetailModal");
+
+function renderWithClient(ui) {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+describe("GroupDetailModal smoke test", () => {
+    it("renders both tabs without crashing", async () => {
+        renderWithClient(
+            <GroupDetailModal
+                open
+                onClose={() => {}}
+                group={{ id: "g1", name: "Test Group", description: "desc" }}
+                users={[{ id: "u1", username: "alice", name: "Alice", surname: "A", email: "a@x.com" }]}
+                printers={[{ id: "p1", name: "Printer1", admits_color: true, is_restricted: false }]}
+            />
+        );
+
+        await waitFor(() => expect(screen.getByText(/Members \(1\)/)).toBeInTheDocument());
+        expect(screen.getByText(/Printer Permits \(1\)/)).toBeInTheDocument();
+        expect(screen.getByText("alice")).toBeInTheDocument();
+    });
+});

--- a/app/src/components/adminComponents/GroupMembersTab.jsx
+++ b/app/src/components/adminComponents/GroupMembersTab.jsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+import { Autocomplete, Button, CircularProgress, Divider, IconButton, List, ListItem, ListItemText, Stack, TextField, Tooltip, Typography } from "@mui/material";
+import DeleteIcon from "@mui/icons-material/Delete";
+import PersonIcon from "@mui/icons-material/Person";
+import { useSnackbar } from "notistack";
+
+import { addGroupMember, removeGroupMember } from "../../api/group";
+import useAsyncAction from "../../hooks/useAsyncAction";
+
+export default function GroupMembersTab({ group, users, detail, refresh }) {
+    const { enqueueSnackbar } = useSnackbar();
+    const [addMemberUser, setAddMemberUser] = useState(null);
+
+    const memberIds = new Set(detail?.members ?? []);
+    const availableUsers = (users ?? []).filter((u) => !memberIds.has(u.id));
+    const memberUsers = (users ?? []).filter((u) => memberIds.has(u.id));
+
+    const [runAddMember, memberLoading] = useAsyncAction(
+        () => addGroupMember(group.id, addMemberUser.id),
+        {
+            onSuccess: () => { setAddMemberUser(null); refresh(); },
+            onError: () => enqueueSnackbar("Failed to add member.", { variant: "error" }),
+        }
+    );
+
+    const [runRemoveMember] = useAsyncAction(
+        (userId) => removeGroupMember(group.id, userId),
+        {
+            onSuccess: () => refresh(),
+            onError: () => enqueueSnackbar("Failed to remove member.", { variant: "error" }),
+        }
+    );
+
+    return (
+        <>
+            {memberUsers.length === 0 ? (
+                <Typography variant="body2" color="text.secondary" fontStyle="italic" sx={{ mb: 2 }}>
+                    No members yet.
+                </Typography>
+            ) : (
+                <List dense disablePadding sx={{ mb: 1 }}>
+                    {memberUsers.map((u) => (
+                        <ListItem
+                            key={u.id}
+                            disableGutters
+                            secondaryAction={
+                                <Tooltip title="Remove from group">
+                                    <IconButton size="small" color="error" onClick={() => runRemoveMember(u.id)} aria-label="Remove from group">
+                                        <DeleteIcon fontSize="small" />
+                                    </IconButton>
+                                </Tooltip>
+                            }
+                        >
+                            <PersonIcon fontSize="small" sx={{ mr: 1, color: "text.secondary" }} />
+                            <ListItemText
+                                primary={u.username}
+                                secondary={`${u.name} ${u.surname} · ${u.email}`}
+                            />
+                        </ListItem>
+                    ))}
+                </List>
+            )}
+            <Divider sx={{ my: 1 }} />
+            <Stack direction="row" spacing={1} alignItems="center">
+                <Autocomplete
+                    size="small"
+                    options={availableUsers}
+                    getOptionLabel={(u) => `${u.username} — ${u.name} ${u.surname}`}
+                    value={addMemberUser}
+                    onChange={(_, v) => setAddMemberUser(v)}
+                    renderInput={(params) => <TextField {...params} label="Add user" />}
+                    sx={{ flexGrow: 1 }}
+                    isOptionEqualToValue={(o, v) => o.id === v.id}
+                />
+                <Button
+                    variant="contained"
+                    size="small"
+                    disabled={!addMemberUser || memberLoading}
+                    onClick={runAddMember}
+                >
+                    {memberLoading ? <CircularProgress size={16} /> : "Add"}
+                </Button>
+            </Stack>
+        </>
+    );
+}

--- a/app/src/components/adminComponents/GroupPrinterPermitsTab.jsx
+++ b/app/src/components/adminComponents/GroupPrinterPermitsTab.jsx
@@ -1,0 +1,230 @@
+import { useState } from "react";
+import { Autocomplete, Button, Chip, CircularProgress, Divider, IconButton, InputAdornment, List, ListItem, ListItemText, Stack, TextField, Tooltip, Typography } from "@mui/material";
+import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
+import CheckIcon from "@mui/icons-material/Check";
+import CloseIcon from "@mui/icons-material/Close";
+import PrintIcon from "@mui/icons-material/Print";
+import LockIcon from "@mui/icons-material/Lock";
+import { useSnackbar } from "notistack";
+
+import { addGroupPrinterPermit, updateGroupPrinterPermit, removeGroupPrinterPermit } from "../../api/group";
+import useAsyncAction from "../../hooks/useAsyncAction";
+
+export default function GroupPrinterPermitsTab({ group, printers, detail, refresh }) {
+    const { enqueueSnackbar } = useSnackbar();
+
+    const [addPermitPrinter, setAddPermitPrinter] = useState(null);
+    const [addPermitBw, setAddPermitBw] = useState("");
+    const [addPermitColor, setAddPermitColor] = useState("");
+    // { printerId, bw, color }
+    const [editingPermit, setEditingPermit] = useState(null);
+
+    const permitPrinterIds = new Set((detail?.printer_permits ?? []).map((p) => p.printer_id));
+    const availablePrinters = (printers ?? []).filter((p) => !permitPrinterIds.has(p.id ?? p.name));
+    const printerById = Object.fromEntries((printers ?? []).map((p) => [p.id ?? p.name, p]));
+
+    const [runAddPermit, permitLoading] = useAsyncAction(
+        () => addGroupPrinterPermit(group.id, {
+            printer_id: addPermitPrinter.id,
+            custom_price_bw: addPermitBw !== "" ? parseFloat(addPermitBw) : null,
+            custom_price_color: addPermitColor !== "" ? parseFloat(addPermitColor) : null,
+        }),
+        {
+            onSuccess: () => {
+                setAddPermitPrinter(null);
+                setAddPermitBw("");
+                setAddPermitColor("");
+                refresh();
+            },
+            onError: () => enqueueSnackbar("Failed to add printer permit.", { variant: "error" }),
+        }
+    );
+
+    const [runUpdatePermit] = useAsyncAction(
+        (printerId) => updateGroupPrinterPermit(group.id, printerId, {
+            custom_price_bw: editingPermit.bw !== "" ? parseFloat(editingPermit.bw) : null,
+            custom_price_color: editingPermit.color !== "" ? parseFloat(editingPermit.color) : null,
+        }),
+        {
+            onSuccess: () => { setEditingPermit(null); refresh(); },
+            onError: () => enqueueSnackbar("Failed to update permit.", { variant: "error" }),
+        }
+    );
+
+    const [runRemovePermit] = useAsyncAction(
+        (printerId) => removeGroupPrinterPermit(group.id, printerId),
+        {
+            onSuccess: () => refresh(),
+            onError: () => enqueueSnackbar("Failed to remove printer permit.", { variant: "error" }),
+        }
+    );
+
+    return (
+        <>
+            {(detail?.printer_permits ?? []).length === 0 ? (
+                <Typography variant="body2" color="text.secondary" fontStyle="italic" sx={{ mb: 2 }}>
+                    No printer permits yet.
+                </Typography>
+            ) : (
+                <List dense disablePadding sx={{ mb: 1 }}>
+                    {(detail?.printer_permits ?? []).map((permit) => {
+                        const printer = printerById[permit.printer_id];
+                        const isEditing = editingPermit?.printerId === permit.printer_id;
+                        return (
+                            <ListItem
+                                key={permit.printer_id}
+                                disableGutters
+                                alignItems="flex-start"
+                                secondaryAction={
+                                    isEditing ? (
+                                        <Stack direction="row" spacing={0.5}>
+                                            <Tooltip title="Save">
+                                                <IconButton size="small" color="success" onClick={() => runUpdatePermit(permit.printer_id)} aria-label="Save">
+                                                    <CheckIcon fontSize="small" />
+                                                </IconButton>
+                                            </Tooltip>
+                                            <Tooltip title="Cancel">
+                                                <IconButton size="small" onClick={() => setEditingPermit(null)} aria-label="Cancel">
+                                                    <CloseIcon fontSize="small" />
+                                                </IconButton>
+                                            </Tooltip>
+                                        </Stack>
+                                    ) : (
+                                        <Stack direction="row" spacing={0.5}>
+                                            <Tooltip title="Edit prices">
+                                                <IconButton size="small" onClick={() => setEditingPermit({
+                                                    printerId: permit.printer_id,
+                                                    bw: permit.custom_price_bw ?? "",
+                                                    color: permit.custom_price_color ?? "",
+                                                })} aria-label="Edit prices">
+                                                    <EditIcon fontSize="small" />
+                                                </IconButton>
+                                            </Tooltip>
+                                            <Tooltip title="Remove permit">
+                                                <IconButton size="small" color="error" onClick={() => runRemovePermit(permit.printer_id)} aria-label="Remove permit">
+                                                    <DeleteIcon fontSize="small" />
+                                                </IconButton>
+                                            </Tooltip>
+                                        </Stack>
+                                    )
+                                }
+                            >
+                                <PrintIcon fontSize="small" sx={{ mr: 1, mt: 0.5, color: "text.secondary", flexShrink: 0 }} />
+                                <ListItemText
+                                    primary={
+                                        <Stack direction="row" spacing={1} alignItems="center">
+                                            <Typography variant="body2" fontWeight="medium">
+                                                {printer?.name ?? permit.printer_id}
+                                            </Typography>
+                                            {printer?.is_restricted && (
+                                                <Chip icon={<LockIcon />} label="Restricted" size="small" color="warning" variant="outlined" />
+                                            )}
+                                        </Stack>
+                                    }
+                                    secondary={
+                                        isEditing ? (
+                                            <Stack direction="row" spacing={1} sx={{ mt: 0.5 }}>
+                                                <TextField
+                                                    size="small"
+                                                    label="B&W price"
+                                                    type="number"
+                                                    value={editingPermit.bw}
+                                                    onChange={(e) => setEditingPermit((p) => ({ ...p, bw: e.target.value }))}
+                                                    placeholder="Default"
+                                                    slotProps={{
+                                                        input: {
+                                                            startAdornment: <InputAdornment position="start">€</InputAdornment>,
+                                                            inputProps: { min: 0, step: 0.001 }
+                                                        }
+                                                    }}
+                                                    sx={{ width: 130 }}
+                                                />
+                                                <TextField
+                                                    size="small"
+                                                    label="Color price"
+                                                    type="number"
+                                                    value={editingPermit.color}
+                                                    onChange={(e) => setEditingPermit((p) => ({ ...p, color: e.target.value }))}
+                                                    placeholder="Default"
+                                                    disabled={!printer?.admits_color}
+                                                    slotProps={{
+                                                        input: {
+                                                            startAdornment: <InputAdornment position="start">€</InputAdornment>,
+                                                            inputProps: { min: 0, step: 0.001 }
+                                                        }
+                                                    }}
+                                                    sx={{ width: 130 }}
+                                                />
+                                            </Stack>
+                                        ) : (
+                                            <Typography variant="caption" color="text.secondary">
+                                                B&W: {permit.custom_price_bw != null ? `€${permit.custom_price_bw.toFixed(3)}` : "Default"}{" · "}
+                                                Color: {permit.custom_price_color != null ? `€${permit.custom_price_color.toFixed(3)}` : "Default"}
+                                            </Typography>
+                                        )
+                                    }
+                                />
+                            </ListItem>
+                        );
+                    })}
+                </List>
+            )}
+            <Divider sx={{ my: 1 }} />
+            <Stack spacing={1}>
+                <Autocomplete
+                    size="small"
+                    options={availablePrinters}
+                    getOptionLabel={(p) => p.name}
+                    value={addPermitPrinter}
+                    onChange={(_, v) => setAddPermitPrinter(v)}
+                    renderInput={(params) => <TextField {...params} label="Add printer" />}
+                    isOptionEqualToValue={(o, v) => (o.id ?? o.name) === (v.id ?? v.name)}
+                />
+                <Stack direction="row" spacing={1} alignItems="center">
+                    <TextField
+                        size="small"
+                        label="Custom B&W price"
+                        type="number"
+                        value={addPermitBw}
+                        onChange={(e) => setAddPermitBw(e.target.value)}
+                        placeholder="Default"
+                        disabled={!addPermitPrinter}
+                        slotProps={{
+                            input: {
+                                startAdornment: <InputAdornment position="start">€</InputAdornment>,
+                                inputProps: { min: 0, step: 0.001 }
+                            }
+                        }}
+                        sx={{ flexGrow: 1 }}
+                    />
+                    <TextField
+                        size="small"
+                        label="Custom color price"
+                        type="number"
+                        value={addPermitColor}
+                        onChange={(e) => setAddPermitColor(e.target.value)}
+                        placeholder="Default"
+                        disabled={!addPermitPrinter || !addPermitPrinter?.admits_color}
+                        slotProps={{
+                            input: {
+                                startAdornment: <InputAdornment position="start">€</InputAdornment>,
+                                inputProps: { min: 0, step: 0.001 }
+                            }
+                        }}
+                        sx={{ flexGrow: 1 }}
+                    />
+                    <Button
+                        variant="contained"
+                        size="small"
+                        disabled={!addPermitPrinter || permitLoading}
+                        onClick={runAddPermit}
+                        sx={{ whiteSpace: "nowrap" }}
+                    >
+                        {permitLoading ? <CircularProgress size={16} /> : "Add"}
+                    </Button>
+                </Stack>
+            </Stack>
+        </>
+    );
+}

--- a/app/src/components/adminComponents/StatCard.jsx
+++ b/app/src/components/adminComponents/StatCard.jsx
@@ -1,0 +1,62 @@
+import { Box, Card, CardContent, Skeleton, Stack, Typography } from "@mui/material";
+
+export default function StatCard({ icon, label, value, accentColor, loading, subtitle }) {
+    return (
+        <Card
+            elevation={0}
+            sx={{
+                height: "100%",
+                borderRadius: 3,
+                border: "1px solid",
+                borderColor: "divider",
+                background: "linear-gradient(180deg, rgba(255,255,255,0.98) 0%, rgba(248,250,252,0.96) 100%)",
+                boxShadow: "0 14px 34px rgba(15, 23, 42, 0.08)"
+            }}
+        >
+            <CardContent sx={{ p: { xs: 1.5, sm: 2 }, "&:last-child": { pb: { xs: 1.5, sm: 2 } } }}>
+                <Stack direction="row" alignItems="center" spacing={1} mb={1}>
+                    <Box
+                        sx={{
+                            p: { xs: 0.75, sm: 1 },
+                            borderRadius: 2,
+                            backgroundColor: `${accentColor}22`,
+                            color: accentColor,
+                            display: "flex",
+                            alignItems: "center",
+                            flexShrink: 0,
+                        }}
+                    >
+                        {icon}
+                    </Box>
+                    <Typography
+                        variant="body2"
+                        color="text.secondary"
+                        lineHeight={1.3}
+                        sx={{ fontSize: { xs: "0.72rem", sm: "0.875rem" } }}
+                    >
+                        {label}
+                    </Typography>
+                </Stack>
+                {loading ? (
+                    <Skeleton width="55%" height={36} />
+                ) : (
+                    <Typography
+                        fontWeight="bold"
+                        sx={{ fontSize: { xs: "1.4rem", sm: "1.75rem", md: "2.125rem" } }}
+                    >
+                        {value}
+                    </Typography>
+                )}
+                {subtitle && (
+                    <Typography
+                        variant="caption"
+                        color="text.disabled"
+                        sx={{ display: { xs: "none", sm: "block" } }}
+                    >
+                        {subtitle}
+                    </Typography>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/app/src/components/adminComponents/StatsBarChart.jsx
+++ b/app/src/components/adminComponents/StatsBarChart.jsx
@@ -1,0 +1,77 @@
+import {
+    BarChart,
+    Bar,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+    Legend,
+    ResponsiveContainer,
+} from "recharts";
+
+function shortLabelMobile(label, maxLen = 9) {
+    if (!label) return "";
+    return label.length > maxLen ? label.slice(0, maxLen - 1) + "…" : label;
+}
+
+// Unifies what used to be two near-identical chart components (a dual B/W
+// vs Color series, and a single Revenue series) — each series and its value
+// formatting is passed in rather than duplicating the mobile/desktop
+// layout logic per chart.
+export default function StatsBarChart({
+    data,
+    height,
+    isMobile,
+    series,
+    valueFormatter = (v) => v.toLocaleString(),
+    tickFormatter,
+    allowDecimals,
+    showLegend = true,
+    desktopMargin = { top: 5, right: 10, left: 0, bottom: 5 },
+}) {
+    const tooltipFormatter = (value, name) => [valueFormatter(value), name];
+    const labelFormatter = (_, payload) => payload?.[0]?.payload?.fullName ?? "";
+
+    if (isMobile) {
+        const mobileData = data.map((d) => ({ ...d, name: shortLabelMobile(d.fullName) }));
+        const barSize = Math.max(10, Math.min(20, Math.floor(220 / (data.length || 1))));
+        return (
+            <ResponsiveContainer width="100%" height={Math.max(height, data.length * 44 + 60)}>
+                <BarChart
+                    data={mobileData}
+                    layout="vertical"
+                    margin={{ top: 5, right: 16, left: 4, bottom: 5 }}
+                >
+                    <CartesianGrid strokeDasharray="3 3" horizontal={false} />
+                    <XAxis
+                        type="number"
+                        tick={{ fontSize: 11 }}
+                        tickFormatter={tickFormatter}
+                        allowDecimals={allowDecimals}
+                    />
+                    <YAxis type="category" dataKey="name" tick={{ fontSize: 11 }} width={72} />
+                    <Tooltip formatter={tooltipFormatter} labelFormatter={labelFormatter} />
+                    {showLegend && <Legend wrapperStyle={{ fontSize: 12 }} />}
+                    {series.map((s) => (
+                        <Bar key={s.dataKey} dataKey={s.dataKey} fill={s.color} radius={[0, 3, 3, 0]} barSize={barSize} />
+                    ))}
+                </BarChart>
+            </ResponsiveContainer>
+        );
+    }
+
+    return (
+        <ResponsiveContainer width="100%" height={height}>
+            <BarChart data={data} margin={desktopMargin}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" tick={{ fontSize: 12 }} />
+                <YAxis tick={{ fontSize: 12 }} tickFormatter={tickFormatter} allowDecimals={allowDecimals} />
+                <Tooltip formatter={tooltipFormatter} labelFormatter={labelFormatter} />
+                {showLegend && <Legend />}
+                {series.map((s) => (
+                    <Bar key={s.dataKey} dataKey={s.dataKey} fill={s.color} radius={[3, 3, 0, 0]} />
+                ))}
+            </BarChart>
+        </ResponsiveContainer>
+    );
+}

--- a/app/src/components/adminComponents/StatsBreakdownTable.jsx
+++ b/app/src/components/adminComponents/StatsBreakdownTable.jsx
@@ -1,0 +1,74 @@
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from "@mui/material";
+
+import StatsTableSkeletonRows from "./StatsTableSkeletonRows";
+
+// Unifies what used to be two near-identical tables (pages-by-printer,
+// pages-by-user) — the only real difference between them is whether a
+// Revenue column applies, and which field backs the "name" column.
+export default function StatsBreakdownTable({ nameHeader, rows, isLoading, isMobile, showRevenue = false }) {
+    const cols = showRevenue ? 6 : 5;
+
+    return (
+        <TableContainer sx={{ overflowX: "auto" }}>
+            <Table size="small" sx={{ minWidth: 300 }}>
+                <TableHead>
+                    <TableRow>
+                        <TableCell><b>{nameHeader}</b></TableCell>
+                        <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
+                            <b>{isMobile ? "Total" : "Total Pages"}</b>
+                        </TableCell>
+                        <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
+                            <b>B/W</b>
+                        </TableCell>
+                        <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
+                            <b>{isMobile ? "Color" : "Color Pages"}</b>
+                        </TableCell>
+                        <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
+                            <b>Sheets</b>
+                        </TableCell>
+                        {showRevenue && (
+                            <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
+                                <b>Revenue</b>
+                            </TableCell>
+                        )}
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {isLoading ? (
+                        <StatsTableSkeletonRows cols={cols} rows={showRevenue ? 3 : 5} />
+                    ) : rows.length === 0 ? (
+                        <TableRow>
+                            <TableCell colSpan={cols}>
+                                <Typography color="text.secondary">No data available.</Typography>
+                            </TableCell>
+                        </TableRow>
+                    ) : (
+                        rows.map((row) => (
+                            <TableRow key={row.key} hover>
+                                <TableCell
+                                    sx={{
+                                        maxWidth: { xs: showRevenue ? 110 : 100, sm: "none" },
+                                        overflow: "hidden",
+                                        textOverflow: "ellipsis",
+                                        whiteSpace: "nowrap",
+                                    }}
+                                >
+                                    {row.name}
+                                </TableCell>
+                                <TableCell align="right">{row.total_pages.toLocaleString()}</TableCell>
+                                <TableCell align="right">{row.bw_pages.toLocaleString()}</TableCell>
+                                <TableCell align="right">{row.color_pages.toLocaleString()}</TableCell>
+                                <TableCell align="right">{row.total_sheets.toLocaleString()}</TableCell>
+                                {showRevenue && (
+                                    <TableCell align="right" sx={{ fontWeight: "bold", color: "success.dark" }}>
+                                        €{row.total_cost.toFixed(2)}
+                                    </TableCell>
+                                )}
+                            </TableRow>
+                        ))
+                    )}
+                </TableBody>
+            </Table>
+        </TableContainer>
+    );
+}

--- a/app/src/components/adminComponents/StatsTableSkeletonRows.jsx
+++ b/app/src/components/adminComponents/StatsTableSkeletonRows.jsx
@@ -1,0 +1,13 @@
+import { Skeleton, TableCell, TableRow } from "@mui/material";
+
+export default function StatsTableSkeletonRows({ cols, rows = 4 }) {
+    return Array.from({ length: rows }).map((_, i) => (
+        <TableRow key={i}>
+            {Array.from({ length: cols }).map((_, j) => (
+                <TableCell key={j}>
+                    <Skeleton />
+                </TableCell>
+            ))}
+        </TableRow>
+    ));
+}

--- a/app/src/components/adminComponents/UserStatusChips.jsx
+++ b/app/src/components/adminComponents/UserStatusChips.jsx
@@ -1,0 +1,10 @@
+import { Chip } from "@mui/material";
+
+export default function UserStatusChips({ user }) {
+    return (
+        <>
+            {user?.is_admin && <Chip label="Admin" color="primary" size="small" />}
+            {!user?.is_active && <Chip label="Inactive" color="error" size="small" />}
+        </>
+    );
+}

--- a/app/src/components/adminComponents/UsersTable.jsx
+++ b/app/src/components/adminComponents/UsersTable.jsx
@@ -1,0 +1,312 @@
+import { useState } from "react";
+import {
+    Box,
+    Button,
+    Dialog,
+    DialogContent,
+    DialogTitle,
+    IconButton,
+    InputAdornment,
+    Paper,
+    Skeleton,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    TextField,
+    Tooltip,
+    Typography,
+} from "@mui/material";
+import EditIcon from "@mui/icons-material/Edit";
+import AccountBalanceWalletIcon from "@mui/icons-material/AccountBalanceWallet";
+import ReceiptLongIcon from "@mui/icons-material/ReceiptLong";
+import SearchIcon from "@mui/icons-material/Search";
+import ClearIcon from "@mui/icons-material/Clear";
+import DeleteIcon from "@mui/icons-material/Delete";
+import CloseIcon from "@mui/icons-material/Close";
+
+import UserStatusChips from "./UserStatusChips";
+
+function getBalanceColor(balance, positiveColor = "success.main") {
+    return balance < 0 ? "error.main" : positiveColor;
+}
+
+// The user directory table + its mobile tap-to-open action sheet — one
+// cohesive interactive unit (a mobile row tap opens the sheet, whose
+// buttons hand off to the parent's edit/recharge/transactions/delete
+// modals via the callbacks below).
+export default function UsersTable({
+    users,
+    usersLoading,
+    isMobile,
+    onEditUser,
+    onRechargeUser,
+    onViewTransactions,
+    onDeleteUser,
+}) {
+    const [search, setSearch] = useState("");
+    const [selectedUser, setSelectedUser] = useState(null);
+
+    const skeletonRows = Array.from({ length: 6 });
+
+    const filteredUsers = (users ?? [])
+        .filter((u) => {
+            const q = search.trim().toLowerCase();
+            if (!q) return true;
+            return (
+                u.username?.toLowerCase().includes(q) ||
+                u.name?.toLowerCase().includes(q) ||
+                u.surname?.toLowerCase().includes(q) ||
+                `${u.name} ${u.surname}`.toLowerCase().includes(q)
+            );
+        })
+        .sort((a, b) => {
+            if (a.is_admin !== b.is_admin) return a.is_admin ? -1 : 1;
+            return (a.username ?? "").localeCompare(b.username ?? "");
+        });
+
+    return (
+        <>
+            <TextField
+                placeholder="Search by name or username…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                size="small"
+                fullWidth
+                slotProps={{
+                    input: {
+                        startAdornment: (
+                            <InputAdornment position="start">
+                                <SearchIcon fontSize="small" />
+                            </InputAdornment>
+                        ),
+                        endAdornment: search ? (
+                            <InputAdornment position="end">
+                                <IconButton size="small" onClick={() => setSearch("")} aria-label="Clear search">
+                                    <ClearIcon fontSize="small" />
+                                </IconButton>
+                            </InputAdornment>
+                        ) : null
+                    }
+                }}
+            />
+
+            <TableContainer
+                component={Paper}
+                elevation={0}
+                sx={{
+                    maxHeight: "calc(80vh - 180px)",
+                    overflowY: "auto",
+                    borderRadius: 2.5,
+                    border: "1px solid",
+                    borderColor: "divider",
+                    boxShadow: "none",
+                    bgcolor: "rgba(255,255,255,0.75)"
+                }}
+            >
+            <Table size="small">
+                <TableHead>
+                    <TableRow>
+                        {isMobile ? (
+                            <>
+                                <TableCell>User</TableCell>
+                                <TableCell align="right">Balance</TableCell>
+                            </>
+                        ) : (
+                            <>
+                                <TableCell>Username</TableCell>
+                                <TableCell>Name</TableCell>
+                                <TableCell>Email</TableCell>
+                                <TableCell>Balance</TableCell>
+                                <TableCell>Roles</TableCell>
+                                <TableCell align="right">Actions</TableCell>
+                            </>
+                        )}
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {usersLoading
+                        ? skeletonRows.map((_, i) => (
+                            <TableRow key={i}>
+                                <TableCell colSpan={isMobile ? 2 : 6}><Skeleton /></TableCell>
+                            </TableRow>
+                        ))
+                        : !users?.length
+                        ? (
+                            <TableRow>
+                                <TableCell colSpan={isMobile ? 2 : 6} align="center">
+                                    <Typography variant="body2" color="text.secondary">
+                                        No users found.
+                                    </Typography>
+                                </TableCell>
+                            </TableRow>
+                        )
+                        : filteredUsers.length === 0 ? (
+                            <TableRow>
+                                <TableCell colSpan={isMobile ? 2 : 6} align="center">
+                                    <Typography variant="body2" color="text.secondary">
+                                        No users match your search.
+                                    </Typography>
+                                </TableCell>
+                            </TableRow>
+                        ) : filteredUsers.map((user) => isMobile ? (
+                            <TableRow
+                                key={user.id}
+                                hover
+                                onClick={() => setSelectedUser(user)}
+                                sx={{ cursor: "pointer" }}
+                            >
+                                <TableCell>
+                                    <Typography variant="body2" fontWeight="medium">
+                                        {user.username}
+                                    </Typography>
+                                    <Typography variant="caption" color="text.secondary">
+                                        {user.name} {user.surname}
+                                    </Typography>
+                                </TableCell>
+                                <TableCell align="right">
+                                    <Typography
+                                        variant="body2"
+                                        fontWeight="medium"
+                                        color={getBalanceColor(user.balance)}
+                                    >
+                                        €{user.balance?.toFixed(2)}
+                                    </Typography>
+                                    <Box display="flex" gap={0.5} justifyContent="flex-end" mt={0.25}>
+                                        <UserStatusChips user={user} />
+                                    </Box>
+                                </TableCell>
+                            </TableRow>
+                        ) : (
+                            <TableRow
+                                key={user.id}
+                                hover
+                                onClick={() => setSelectedUser(user)}
+                                sx={{ cursor: "pointer" }}
+                            >
+                                <TableCell>
+                                    <Typography variant="body2" fontWeight="medium">
+                                        {user.username}
+                                    </Typography>
+                                </TableCell>
+                                <TableCell>{user.name} {user.surname}</TableCell>
+                                <TableCell>{user.email}</TableCell>
+                                <TableCell>
+                                    <Typography
+                                        variant="body2"
+                                        color={getBalanceColor(user.balance, "text.primary")}
+                                    >
+                                        €{user.balance?.toFixed(2)}
+                                    </Typography>
+                                </TableCell>
+                                <TableCell>
+                                    <Box display="flex" gap={0.5}>
+                                        <UserStatusChips user={user} />
+                                    </Box>
+                                </TableCell>
+                                <TableCell align="right">
+                                    <Tooltip title="Edit user info">
+                                        <IconButton size="small" onClick={(e) => { e.stopPropagation(); onEditUser(user); }} aria-label="Edit user info">
+                                            <EditIcon fontSize="small" />
+                                        </IconButton>
+                                    </Tooltip>
+                                    <Tooltip title="Adjust balance">
+                                        <IconButton size="small" onClick={(e) => { e.stopPropagation(); onRechargeUser(user); }} aria-label="Adjust balance">
+                                            <AccountBalanceWalletIcon fontSize="small" />
+                                        </IconButton>
+                                    </Tooltip>
+                                    <Tooltip title="View transactions">
+                                        <IconButton size="small" onClick={(e) => { e.stopPropagation(); onViewTransactions(user); }} aria-label="View transactions">
+                                            <ReceiptLongIcon fontSize="small" />
+                                        </IconButton>
+                                    </Tooltip>
+                                    <Tooltip title="Delete user">
+                                        <IconButton size="small" color="error" onClick={(e) => { e.stopPropagation(); onDeleteUser(user); }} aria-label="Delete user">
+                                            <DeleteIcon fontSize="small" />
+                                        </IconButton>
+                                    </Tooltip>
+                                </TableCell>
+                            </TableRow>
+                        ))
+                    }
+                </TableBody>
+            </Table>
+            </TableContainer>
+
+            {/* Mobile action sheet */}
+            <Dialog
+                open={Boolean(selectedUser)}
+                onClose={() => setSelectedUser(null)}
+                fullWidth
+                maxWidth="xs"
+            >
+                <DialogTitle sx={{ pb: 0.5, pr: 6 }}>
+                    <Typography fontWeight="bold">{selectedUser?.username}</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                        {selectedUser?.name} {selectedUser?.surname}
+                    </Typography>
+                    <IconButton
+                        onClick={() => setSelectedUser(null)}
+                        size="small"
+                        sx={{ position: "absolute", top: 8, right: 8 }}
+                        aria-label="Close"
+                    >
+                        <CloseIcon fontSize="small" />
+                    </IconButton>
+                </DialogTitle>
+                <DialogContent>
+                    <Typography variant="body2" color="text.secondary" gutterBottom>
+                        {selectedUser?.email}
+                    </Typography>
+                    <Box display="flex" alignItems="center" gap={1} mt={0.5}>
+                        <Typography
+                            variant="body1"
+                            fontWeight="medium"
+                            color={getBalanceColor(selectedUser?.balance)}
+                        >
+                            €{selectedUser?.balance?.toFixed(2)}
+                        </Typography>
+                        <UserStatusChips user={selectedUser} />
+                    </Box>
+                </DialogContent>
+                <Box sx={{ display: "flex", flexDirection: "column", gap: 1, px: 2, pb: 2 }}>
+                    <Button
+                        fullWidth
+                        variant="outlined"
+                        startIcon={<EditIcon />}
+                        onClick={() => { onEditUser(selectedUser); setSelectedUser(null); }}
+                    >
+                        Edit Info
+                    </Button>
+                    <Button
+                        fullWidth
+                        variant="outlined"
+                        startIcon={<AccountBalanceWalletIcon />}
+                        onClick={() => { onRechargeUser(selectedUser); setSelectedUser(null); }}
+                    >
+                        Recharge / Adjust Balance
+                    </Button>
+                    <Button
+                        fullWidth
+                        variant="outlined"
+                        startIcon={<ReceiptLongIcon />}
+                        onClick={() => { onViewTransactions(selectedUser); setSelectedUser(null); }}
+                    >
+                        View Transactions
+                    </Button>
+                    <Button
+                        fullWidth
+                        variant="outlined"
+                        color="error"
+                        startIcon={<DeleteIcon />}
+                        onClick={() => { onDeleteUser(selectedUser); setSelectedUser(null); }}
+                    >
+                        Delete User
+                    </Button>
+                </Box>
+            </Dialog>
+        </>
+    );
+}

--- a/app/src/components/balanceComponents/BalanceHeader.test.jsx
+++ b/app/src/components/balanceComponents/BalanceHeader.test.jsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import BalanceHeader from "./BalanceHeader";
+
+describe("BalanceHeader", () => {
+    it("shows a loading skeleton", () => {
+        const { container } = render(<BalanceHeader user={null} isLoading isError={false} />);
+        expect(container.querySelector(".MuiSkeleton-root")).toBeInTheDocument();
+    });
+
+    it("shows a distinct error state instead of spinning forever", () => {
+        render(<BalanceHeader user={null} isLoading={false} isError />);
+        expect(screen.getByText("Unavailable")).toBeInTheDocument();
+        expect(screen.queryByText(/^€/)).not.toBeInTheDocument();
+    });
+
+    it("shows the formatted balance on success", () => {
+        render(<BalanceHeader user={{ balance: 12.5 }} isLoading={false} isError={false} />);
+        expect(screen.getByText("€12.50")).toBeInTheDocument();
+    });
+});

--- a/app/src/components/printComponents/printSteps/CostSummaryCard.jsx
+++ b/app/src/components/printComponents/printSteps/CostSummaryCard.jsx
@@ -1,0 +1,201 @@
+import { Box, Chip, Paper, Stack, Typography } from "@mui/material";
+import AccountBalanceWalletOutlinedIcon from "@mui/icons-material/AccountBalanceWalletOutlined";
+
+import LoadingTypography from "../../utils/LoadingTypography";
+
+export default function CostSummaryCard({
+    isMobile,
+    hasEnoughCredit,
+    allValid,
+    totalCost,
+    isLoadingFiles,
+    isLoadingUser,
+    currentBalance,
+    remainingBalance,
+    selectedFilesCount,
+    totalPages,
+}) {
+    const borderColor = hasEnoughCredit ? "divider" : "error.light";
+    const backgroundColor = hasEnoughCredit ? "background.paper" : "rgba(211,47,47,0.04)";
+
+    if (isMobile) {
+        return (
+            <Paper
+                elevation={0}
+                sx={{
+                    p: { xs: 1.1, sm: 1.5 },
+                    height: "100%",
+                    display: "flex",
+                    flexDirection: "column",
+                    borderRadius: 3,
+                    border: "1px solid",
+                    borderColor,
+                    backgroundColor,
+                    minWidth: 0,
+                    overflow: "hidden",
+                }}
+            >
+                <Stack spacing={1.1} sx={{ flex: 1, minWidth: 0 }}>
+                    <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={1}>
+                        <Box sx={{ minWidth: 0, flex: 1 }}>
+                            <Typography variant="caption" color="text.secondary">
+                                Total
+                            </Typography>
+                            <LoadingTypography
+                                variant="h5"
+                                color={hasEnoughCredit ? "primary" : "error"}
+                                sx={{ fontWeight: 700, lineHeight: 1.05 }}
+                                loadingWidth={90}
+                                isLoading={isLoadingFiles}
+                            >
+                                €{totalCost.toFixed(2)}
+                            </LoadingTypography>
+                        </Box>
+                        <Box
+                            sx={{
+                                width: 34,
+                                height: 34,
+                                display: "grid",
+                                placeItems: "center",
+                                borderRadius: 2.5,
+                                backgroundColor: "rgba(15,23,42,0.06)",
+                                flexShrink: 0,
+                            }}
+                        >
+                            <AccountBalanceWalletOutlinedIcon fontSize="small" />
+                        </Box>
+                    </Stack>
+
+                    <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap" sx={{ minWidth: 0 }}>
+                        <Chip label={`${selectedFilesCount} file${selectedFilesCount === 1 ? "" : "s"}`} sx={{ borderRadius: 999, height: 20, "& .MuiChip-label": { px: 1, fontSize: "0.7rem" } }} />
+                        <Chip label={`${totalPages} page${totalPages === 1 ? "" : "s"}`} sx={{ borderRadius: 999, height: 20, "& .MuiChip-label": { px: 1, fontSize: "0.7rem" } }} />
+                    </Stack>
+
+                    <Box
+                        sx={{
+                            display: "grid",
+                            gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+                            gap: 1,
+                            minWidth: 0,
+                        }}
+                    >
+                        <Box sx={{ p: 1, borderRadius: 2.5, backgroundColor: "rgba(15,23,42,0.04)", minWidth: 0, overflow: "hidden" }}>
+                            <Typography variant="caption" color="text.secondary">
+                                Balance
+                            </Typography>
+                            <LoadingTypography
+                                variant="body2"
+                                fontWeight={700}
+                                loadingWidth={70}
+                                isLoading={isLoadingUser}
+                            >
+                                €{currentBalance.toFixed(2)}
+                            </LoadingTypography>
+                        </Box>
+                        <Box sx={{ p: 1, borderRadius: 2.5, backgroundColor: "rgba(15,23,42,0.04)", minWidth: 0, overflow: "hidden" }}>
+                            <Typography variant="caption" color="text.secondary">
+                                After
+                            </Typography>
+                            <Typography variant="body2" fontWeight={700} noWrap sx={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+                                €{remainingBalance.toFixed(2)}
+                            </Typography>
+                        </Box>
+                    </Box>
+
+                    {!hasEnoughCredit && (
+                        <Typography variant="caption" color="error" fontWeight={700}>
+                            Not enough credit.
+                        </Typography>
+                    )}
+                    {hasEnoughCredit && !allValid && (
+                        <Typography variant="caption" color="error" fontWeight={700}>
+                            Fix invalid print options before sending.
+                        </Typography>
+                    )}
+                </Stack>
+            </Paper>
+        );
+    }
+
+    return (
+        <Paper
+            elevation={0}
+            sx={{
+                p: 1.75,
+                minWidth: 0,
+                flex: 1,
+                minHeight: 0,
+                borderRadius: 3,
+                border: "1px solid",
+                borderColor,
+                backgroundColor,
+                display: "flex",
+                flexDirection: "column",
+                justifyContent: "space-between",
+            }}
+        >
+            <Stack direction="row" spacing={1.25} alignItems="center">
+                <Box
+                    sx={{
+                        width: 40,
+                        height: 40,
+                        display: "grid",
+                        placeItems: "center",
+                        borderRadius: 2.5,
+                        backgroundColor: "rgba(15,23,42,0.06)",
+                        flexShrink: 0,
+                    }}
+                >
+                    <AccountBalanceWalletOutlinedIcon />
+                </Box>
+                <Box sx={{ minWidth: 0 }}>
+                    <Typography variant="body1" fontWeight={700}>
+                        Cost summary
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                        Estimated total before sending the print job.
+                    </Typography>
+                </Box>
+            </Stack>
+
+            <Box>
+                <Typography variant="body2" color="text.secondary">
+                    Total cost
+                </Typography>
+                <LoadingTypography
+                    variant="h4"
+                    color={hasEnoughCredit ? "primary" : "error"}
+                    sx={{ fontWeight: 700, lineHeight: 1.15 }}
+                    loadingWidth={90}
+                    isLoading={isLoadingFiles}
+                >
+                    €{totalCost.toFixed(2)}
+                </LoadingTypography>
+            </Box>
+
+            <Stack spacing={0.5}>
+                <LoadingTypography
+                    color="text.secondary"
+                    variant="body2"
+                    loadingWidth={150}
+                    isLoading={isLoadingUser}
+                >
+                    {`Current balance: €${currentBalance.toFixed(2)}`}
+                </LoadingTypography>
+                <Typography variant="body2" color="text.secondary">
+                    {`Balance after print: €${remainingBalance.toFixed(2)}`}
+                </Typography>
+                {!hasEnoughCredit && (
+                    <Typography variant="body2" color="error" fontWeight={600}>
+                        Insufficient credit. Add funds or adjust the print settings to continue.
+                    </Typography>
+                )}
+                {hasEnoughCredit && !allValid && (
+                    <Typography variant="body2" color="error" fontWeight={600}>
+                        Fix invalid print options before sending.
+                    </Typography>
+                )}
+            </Stack>
+        </Paper>
+    );
+}

--- a/app/src/components/printComponents/printSteps/FilesListCard.jsx
+++ b/app/src/components/printComponents/printSteps/FilesListCard.jsx
@@ -1,0 +1,133 @@
+import { Box, Chip, List, ListItem, ListItemText, Paper, Stack, Typography } from "@mui/material";
+import ReceiptLongOutlinedIcon from "@mui/icons-material/ReceiptLongOutlined";
+
+import { countPagesInRange } from "../../printCoreFunctions/calculateCost";
+import LoadingList from "../../utils/LoadingList";
+
+export default function FilesListCard({
+    isMobile,
+    height,
+    selectedFiles,
+    isLoadingFiles,
+    selectedIds,
+    printerOptionsByFile,
+    totalPages,
+}) {
+    return (
+        <Paper
+            elevation={0}
+            sx={{
+                p: isMobile ? { xs: 1.1, sm: 1.5 } : 1.5,
+                height,
+                borderRadius: 3,
+                border: "1px solid",
+                borderColor: "divider",
+                minWidth: 0,
+                overflow: "hidden",
+                display: "flex",
+                flexDirection: "column",
+            }}
+        >
+            <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={1} sx={{ minWidth: 0 }}>
+                <Box sx={{ minWidth: 0, flex: 1 }}>
+                    <Typography variant={isMobile ? "body1" : "body1"} fontWeight={700}>
+                        {isMobile ? "Files" : "Files in this print job"}
+                    </Typography>
+                    <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={
+                            isMobile
+                                ? { display: "block", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }
+                                : { display: "block", lineHeight: 1.35 }
+                        }
+                    >
+                        {isMobile
+                            ? `${selectedFiles.length} file${selectedFiles.length === 1 ? "" : "s"}, ${totalPages} page${totalPages === 1 ? "" : "s"}`
+                            : `${selectedFiles.length} file${selectedFiles.length === 1 ? "" : "s"} and ${totalPages} printable page${totalPages === 1 ? "" : "s"}.`}
+                    </Typography>
+                </Box>
+                <ReceiptLongOutlinedIcon color="action" sx={{ flexShrink: 0 }} />
+            </Stack>
+
+            <Box sx={{ mt: isMobile ? 0.75 : 0.9, minWidth: 0, flex: 1, minHeight: 0 }}>
+                {isLoadingFiles ? (
+                    <LoadingList count={selectedIds.length} sx={{ overflowY: "auto", maxHeight: "calc(60vh - 280px)" }} />
+                ) : selectedFiles.length === 0 ? (
+                    <Typography variant="body2" color="text.secondary">
+                        No files selected
+                    </Typography>
+                ) : (
+                    <List sx={{ overflowY: "auto", overflowX: "hidden", height: "100%", p: 0, minWidth: 0 }}>
+                        {selectedFiles.map(file => {
+                            const opts = printerOptionsByFile[file.id];
+                            const pagesCount = countPagesInRange(opts?.pageRanges, file.pages) * (opts?.copies || 1);
+                            return (
+                                <ListItem
+                                    key={file.id}
+                                    disablePadding
+                                    sx={{
+                                        py: isMobile ? 0.75 : 1.15,
+                                        display: "block",
+                                        "&:not(:last-child)": {
+                                            borderBottom: "1px solid",
+                                            borderColor: "divider",
+                                        },
+                                    }}
+                                >
+                                    {isMobile ? (
+                                        <ListItemText
+                                            sx={{ minWidth: 0, m: 0 }}
+                                            primary={
+                                                <Stack direction="row" spacing={1} alignItems="center" sx={{ minWidth: 0 }}>
+                                                    <Typography
+                                                        variant="body2"
+                                                        fontWeight={700}
+                                                        noWrap
+                                                        sx={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis" }}
+                                                    >
+                                                        {file.filename}
+                                                    </Typography>
+                                                    <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
+                                                        {pagesCount}p
+                                                    </Typography>
+                                                </Stack>
+                                            }
+                                            secondary={
+                                                <Typography variant="caption" color="text.secondary" sx={{ mt: 0.2, display: "block" }}>
+                                                    {opts?.copies || 1} cop{(opts?.copies || 1) === 1 ? "y" : "ies"}
+                                                </Typography>
+                                            }
+                                        />
+                                    ) : (
+                                        <ListItemText
+                                            sx={{ minWidth: 0, m: 0 }}
+                                            primary={
+                                                <Typography
+                                                    variant="body2"
+                                                    fontWeight={700}
+                                                    noWrap
+                                                    sx={{ overflow: "hidden", textOverflow: "ellipsis" }}
+                                                >
+                                                    {file.filename}
+                                                </Typography>
+                                            }
+                                            secondary={
+                                                <Stack direction="row" spacing={0.8} useFlexGap flexWrap="wrap" sx={{ mt: 0.65 }}>
+                                                    <Chip size="small" variant="outlined" label={`${pagesCount} page${pagesCount === 1 ? "" : "s"}`} sx={{ borderRadius: 999, height: 22, "& .MuiChip-label": { px: 1, fontSize: "0.72rem" } }} />
+                                                    <Chip size="small" variant="outlined" label={`${opts?.copies || 1} cop${(opts?.copies || 1) === 1 ? "y" : "ies"}`} sx={{ borderRadius: 999, height: 22, "& .MuiChip-label": { px: 1, fontSize: "0.72rem" } }} />
+                                                    <Chip size="small" variant="outlined" label={opts?.colorMode || "B&W"} sx={{ borderRadius: 999, height: 22, "& .MuiChip-label": { px: 1, fontSize: "0.72rem" } }} />
+                                                    <Chip size="small" variant="outlined" label={opts?.sides === "1S" ? "One-sided" : "Two-sided"} sx={{ borderRadius: 999, height: 22, "& .MuiChip-label": { px: 1, fontSize: "0.72rem" } }} />
+                                                </Stack>
+                                            }
+                                        />
+                                    )}
+                                </ListItem>
+                            );
+                        })}
+                    </List>
+                )}
+            </Box>
+        </Paper>
+    );
+}

--- a/app/src/components/printComponents/printSteps/PrinterInfoCard.jsx
+++ b/app/src/components/printComponents/printSteps/PrinterInfoCard.jsx
@@ -1,0 +1,50 @@
+import { Box, Paper, Stack, Typography } from "@mui/material";
+import PrintIcon from "@mui/icons-material/Print";
+
+export default function PrinterInfoCard({ printer, isMobile }) {
+    return (
+        <Paper
+            elevation={0}
+            sx={{
+                p: isMobile ? { xs: 1.1, sm: 1.5 } : 1.35,
+                height: isMobile ? "auto" : 96,
+                borderRadius: 3,
+                border: "1px solid",
+                borderColor: "divider",
+                minWidth: 0,
+                overflow: "hidden",
+                ...(isMobile ? {} : { display: "flex", flexDirection: "column", justifyContent: "center" }),
+            }}
+        >
+            <Stack direction="row" spacing={isMobile ? { xs: 1, sm: 1.5 } : 1.25} alignItems="center" sx={{ minWidth: 0 }}>
+                <Box
+                    sx={{
+                        width: isMobile ? { xs: 34, sm: 40 } : 38,
+                        height: isMobile ? { xs: 34, sm: 40 } : 38,
+                        display: "grid",
+                        placeItems: "center",
+                        borderRadius: isMobile ? 2.5 : 2.25,
+                        backgroundColor: "rgba(25,118,210,0.10)",
+                        color: "primary.main",
+                        flexShrink: 0,
+                    }}
+                >
+                    <PrintIcon fontSize={isMobile ? "small" : "medium"} />
+                </Box>
+                <Box sx={{ minWidth: 0 }}>
+                    <Typography variant={isMobile ? "body2" : "body1"} fontWeight={700} noWrap>
+                        {printer?.name}
+                    </Typography>
+                    <Typography
+                        variant={isMobile ? "caption" : "body2"}
+                        color="text.secondary"
+                        noWrap
+                        sx={{ display: "block", overflow: "hidden", textOverflow: "ellipsis" }}
+                    >
+                        {printer?.location}
+                    </Typography>
+                </Box>
+            </Stack>
+        </Paper>
+    );
+}

--- a/app/src/components/printComponents/printSteps/StepSend.jsx
+++ b/app/src/components/printComponents/printSteps/StepSend.jsx
@@ -1,27 +1,22 @@
-import { 
-    Box, Button, Chip, Divider, List, ListItem, ListItemText, Paper, Stack, Typography,
+import {
+    Box, Button, Stack, Typography,
     CircularProgress, useMediaQuery, useTheme
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import PrintIcon from "@mui/icons-material/Print";
-import AccountBalanceWalletOutlinedIcon from "@mui/icons-material/AccountBalanceWalletOutlined";
-import ReceiptLongOutlinedIcon from "@mui/icons-material/ReceiptLongOutlined";
-
-import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
 
 import { usePrinter } from "../../../context/PrinterContext";
 import { useFile } from "../../../context/FileContext";
 import { usePrint } from "../../../context/PrintContext";
 import { useUser } from "../../../context/UserContext";
 
-import { print } from "../../../api/print";
-import { calculateTotalCost, countPagesInRange } from "../../printCoreFunctions/calculateCost";
+import usePrintSummary from "../../../hooks/usePrintSummary";
+import useSubmitPrint from "../../../hooks/useSubmitPrint";
 
-import LoadingTypography from '../../utils/LoadingTypography'
-import LoadingList from "../../utils/LoadingList";
 import CustomModal from "../../utils/CustomModal";
-import { useSnackbar } from "notistack";
+import PrinterInfoCard from "./PrinterInfoCard";
+import FilesListCard from "./FilesListCard";
+import CostSummaryCard from "./CostSummaryCard";
 
 
 export default function StepSend({ onPrev }) {
@@ -33,76 +28,23 @@ export default function StepSend({ onPrev }) {
     const { selectedPrinter } = usePrinter();
     const { selectedIds, files, isLoading: isLoadingFiles } = useFile();
     const { printerOptionsByFile, validByFile } = usePrint();
-    const { enqueueSnackbar } = useSnackbar();
 
-    const [ selectedFiles, setSelectedFiles ] = useState([]);
-    const [ totalCost, setTotalCost ] = useState(0);
-    const [ isPrinting, setIsPrinting ] = useState(false)
-
-    const navigate = useNavigate();
-
-    useEffect(() => {
-        setSelectedFiles(files?.filter(f => selectedIds.includes(f.id)) || [])
-        const value = calculateTotalCost(
-            files?.filter(f => selectedIds.includes(f.id)) || [],
-            printerOptionsByFile, 
-            selectedPrinter
-        )
-        setTotalCost(value);
-    }, [files, selectedIds, printerOptionsByFile, selectedPrinter])
+    const { selectedFiles, totalCost, totalPages } = usePrintSummary(
+        files, selectedIds, printerOptionsByFile, selectedPrinter
+    );
+    const { isPrinting, handlePrint } = useSubmitPrint({
+        selectedIds, selectedPrinter, printerOptionsByFile, selectedFiles
+    });
 
     const currentBalance = Math.round(((user?.balance || 0) + Number.EPSILON) * 100) / 100;
     const creditLimit = Math.round(((user?.credit_limit || 0) + Number.EPSILON) * 100) / 100;
     const availableToSpend = Math.round(((currentBalance + creditLimit) + Number.EPSILON) * 100) / 100;
     const hasEnoughCredit = availableToSpend >= totalCost;
     const allValid = selectedFiles.every(f => !Object.prototype.hasOwnProperty.call(validByFile, f.id) || validByFile[f.id]);
-    const totalPages = selectedFiles.reduce((sum, file) => {
-        const opts = printerOptionsByFile[file.id];
-        return sum + countPagesInRange(opts?.pageRanges, file.pages) * (opts?.copies || 1);
-    }, 0);
     const remainingBalance = Math.round(((currentBalance - totalCost) + Number.EPSILON) * 100) / 100;
 
     const handleBack = () => {
         onPrev?.();
-    }
-
-    const handlePrint = async () => {
-        setIsPrinting(true);
-
-        const printStatus = {};
-
-        for (let i = 0; i < selectedIds.length; i++) {
-            const id = selectedIds[i];
-            printStatus[id] = {
-                status: false,
-                message: ""
-            }
-
-            try {
-                await print(selectedPrinter.name, id, printerOptionsByFile[id]);
-                printStatus[id].status = true;
-
-            } catch (err) {
-                printStatus[id].message = err.message
-            }
-
-        }
-        
-        const filesMap = Object.fromEntries(selectedFiles.map(obj => [obj.id, obj]));
-        setTimeout(() => {
-            setIsPrinting(false);
-
-            for (const key in printStatus) {
-                const status = printStatus[key].status;
-                if (status) {
-                    enqueueSnackbar(`File ${filesMap[key].filename} queued`, { variant: "success" })
-                } else {
-                    enqueueSnackbar(`Could not print ${filesMap[key].filename}. Try again later.`, { variant: "error" })
-                }
-            }
-            
-            navigate("/");
-        }, 800);
     }
 
     return (
@@ -126,220 +68,30 @@ export default function StepSend({ onPrev }) {
                     {isMobile ? (
                         <>
                             <Stack spacing={2} sx={{ minWidth: 0 }}>
-                                <Paper
-                                    elevation={0}
-                                    sx={{
-                                        p: { xs: 1.1, sm: 1.5 },
-                                        borderRadius: 3,
-                                        border: "1px solid",
-                                        borderColor: "divider",
-                                        minWidth: 0,
-                                        overflow: "hidden",
-                                    }}
-                                >
-                                    <Stack direction="row" spacing={{ xs: 1, sm: 1.5 }} alignItems="center" sx={{ minWidth: 0 }}>
-                                        <Box
-                                            sx={{
-                                                width: { xs: 34, sm: 40 },
-                                                height: { xs: 34, sm: 40 },
-                                                display: "grid",
-                                                placeItems: "center",
-                                                borderRadius: 2.5,
-                                                backgroundColor: "rgba(25,118,210,0.10)",
-                                                color: "primary.main",
-                                                flexShrink: 0,
-                                            }}
-                                        >
-                                            <PrintIcon fontSize={isMobile ? "small" : "medium"} />
-                                        </Box>
-                                        <Box sx={{ minWidth: 0 }}>
-                                            <Typography variant="body2" fontWeight={700} noWrap>
-                                                {selectedPrinter?.name}
-                                            </Typography>
-                                            <Typography variant="caption" color="text.secondary" noWrap sx={{ display: "block", overflow: "hidden", textOverflow: "ellipsis" }}>
-                                                {selectedPrinter?.location}
-                                            </Typography>
-                                        </Box>
-                                    </Stack>
-                                </Paper>
-
-                                <Paper
-                                    elevation={0}
-                                    sx={{
-                                        p: 1.5,
-                                        height: 210,
-                                        borderRadius: 3,
-                                        border: "1px solid",
-                                        borderColor: "divider",
-                                        minWidth: 0,
-                                        overflow: "hidden",
-                                        display: "flex",
-                                        flexDirection: "column",
-                                    }}
-                                >
-                                    <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={1} sx={{ minWidth: 0 }}>
-                                        <Box sx={{ minWidth: 0, flex: 1 }}>
-                                            <Typography variant="body1" fontWeight={700}>
-                                                Files
-                                            </Typography>
-                                            <Typography variant="caption" color="text.secondary" sx={{ display: "block", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                                                {`${selectedFiles.length} file${selectedFiles.length === 1 ? "" : "s"}, ${totalPages} page${totalPages === 1 ? "" : "s"}`}
-                                            </Typography>
-                                        </Box>
-                                        <ReceiptLongOutlinedIcon color="action" sx={{ flexShrink: 0 }} />
-                                    </Stack>
-
-                                    <Box sx={{ mt: 0.75, minWidth: 0, flex: 1, minHeight: 0 }}>
-                                        {isLoadingFiles ? (
-                                            <LoadingList count={selectedIds.length} sx={{ overflowY: "auto", maxHeight: "calc(60vh - 280px)" }} />
-                                        ) : selectedFiles.length === 0 ? (
-                                            <Typography variant="body2" color="text.secondary">
-                                                No files selected
-                                            </Typography>
-                                        ) : (
-                                            <List sx={{ overflowY: "auto", overflowX: "hidden", height: "100%", p: 0, minWidth: 0 }}>
-                                                {selectedFiles.map(file => {
-                                                    const opts = printerOptionsByFile[file.id];
-                                                    const pagesCount = countPagesInRange(opts?.pageRanges, file.pages) * (opts?.copies || 1);
-                                                    return (
-                                                        <ListItem
-                                                            key={file.id}
-                                                            disablePadding
-                                                            sx={{
-                                                                py: 0.75,
-                                                                display: "block",
-                                                                "&:not(:last-child)": {
-                                                                    borderBottom: "1px solid",
-                                                                    borderColor: "divider",
-                                                                },
-                                                            }}
-                                                        >
-                                                            <ListItemText
-                                                                sx={{ minWidth: 0, m: 0 }}
-                                                                primary={
-                                                                    <Stack direction="row" spacing={1} alignItems="center" sx={{ minWidth: 0 }}>
-                                                                        <Typography
-                                                                            variant="body2"
-                                                                            fontWeight={700}
-                                                                            noWrap
-                                                                            sx={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis" }}
-                                                                        >
-                                                                            {file.filename}
-                                                                        </Typography>
-                                                                        <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
-                                                                            {pagesCount}p
-                                                                        </Typography>
-                                                                    </Stack>
-                                                                }
-                                                                secondary={
-                                                                    <Typography variant="caption" color="text.secondary" sx={{ mt: 0.2, display: "block" }}>
-                                                                        {opts?.copies || 1} cop{(opts?.copies || 1) === 1 ? "y" : "ies"}
-                                                                    </Typography>
-                                                                }
-                                                            />
-                                                        </ListItem>
-                                                    );
-                                                })}
-                                            </List>
-                                        )}
-                                    </Box>
-                                </Paper>
+                                <PrinterInfoCard printer={selectedPrinter} isMobile />
+                                <FilesListCard
+                                    isMobile
+                                    height={210}
+                                    selectedFiles={selectedFiles}
+                                    isLoadingFiles={isLoadingFiles}
+                                    selectedIds={selectedIds}
+                                    printerOptionsByFile={printerOptionsByFile}
+                                    totalPages={totalPages}
+                                />
                             </Stack>
 
-                            <Paper
-                                elevation={0}
-                                sx={{
-                                    p: { xs: 1.1, sm: 1.5 },
-                                    height: "100%",
-                                    display: "flex",
-                                    flexDirection: "column",
-                                    borderRadius: 3,
-                                    border: "1px solid",
-                                    borderColor: hasEnoughCredit ? "divider" : "error.light",
-                                    backgroundColor: hasEnoughCredit ? "background.paper" : "rgba(211,47,47,0.04)",
-                                    minWidth: 0,
-                                    overflow: "hidden",
-                                }}
-                            >
-                                <Stack spacing={1.1} sx={{ flex: 1, minWidth: 0 }}>
-                                    <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={1}>
-                                        <Box sx={{ minWidth: 0, flex: 1 }}>
-                                            <Typography variant="caption" color="text.secondary">
-                                                Total
-                                            </Typography>
-                                            <LoadingTypography
-                                                variant="h5"
-                                                color={hasEnoughCredit ? "primary" : "error"}
-                                                sx={{ fontWeight: 700, lineHeight: 1.05 }}
-                                                loadingWidth={90}
-                                                isLoading={isLoadingFiles}
-                                            >
-                                                €{totalCost.toFixed(2)}
-                                            </LoadingTypography>
-                                        </Box>
-                                        <Box
-                                            sx={{
-                                                width: 34,
-                                                height: 34,
-                                                display: "grid",
-                                                placeItems: "center",
-                                                borderRadius: 2.5,
-                                                backgroundColor: "rgba(15,23,42,0.06)",
-                                                flexShrink: 0,
-                                            }}
-                                        >
-                                            <AccountBalanceWalletOutlinedIcon fontSize="small" />
-                                        </Box>
-                                    </Stack>
-
-                                    <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap" sx={{ minWidth: 0 }}>
-                                        <Chip label={`${selectedFiles.length} file${selectedFiles.length === 1 ? "" : "s"}`} sx={{ borderRadius: 999, height: 20, "& .MuiChip-label": { px: 1, fontSize: "0.7rem" } }} />
-                                        <Chip label={`${totalPages} page${totalPages === 1 ? "" : "s"}`} sx={{ borderRadius: 999, height: 20, "& .MuiChip-label": { px: 1, fontSize: "0.7rem" } }} />
-                                    </Stack>
-
-                                    <Box
-                                        sx={{
-                                            display: "grid",
-                                            gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
-                                            gap: 1,
-                                            minWidth: 0,
-                                        }}
-                                    >
-                                        <Box sx={{ p: 1, borderRadius: 2.5, backgroundColor: "rgba(15,23,42,0.04)", minWidth: 0, overflow: "hidden" }}>
-                                            <Typography variant="caption" color="text.secondary">
-                                                Balance
-                                            </Typography>
-                                            <LoadingTypography
-                                                variant="body2"
-                                                fontWeight={700}
-                                                loadingWidth={70}
-                                                isLoading={isLoadingUser}
-                                            >
-                                                €{currentBalance.toFixed(2)}
-                                            </LoadingTypography>
-                                        </Box>
-                                        <Box sx={{ p: 1, borderRadius: 2.5, backgroundColor: "rgba(15,23,42,0.04)", minWidth: 0, overflow: "hidden" }}>
-                                            <Typography variant="caption" color="text.secondary">
-                                                After
-                                            </Typography>
-                                            <Typography variant="body2" fontWeight={700} noWrap sx={{ overflow: "hidden", textOverflow: "ellipsis" }}>
-                                                €{remainingBalance.toFixed(2)}
-                                            </Typography>
-                                        </Box>
-                                    </Box>
-
-                                    {!hasEnoughCredit && (
-                                        <Typography variant="caption" color="error" fontWeight={700}>
-                                            Not enough credit.
-                                        </Typography>
-                                    )}
-                                    {hasEnoughCredit && !allValid && (
-                                        <Typography variant="caption" color="error" fontWeight={700}>
-                                            Fix invalid print options before sending.
-                                        </Typography>
-                                    )}
-                                </Stack>
-                            </Paper>
+                            <CostSummaryCard
+                                isMobile
+                                hasEnoughCredit={hasEnoughCredit}
+                                allValid={allValid}
+                                totalCost={totalCost}
+                                isLoadingFiles={isLoadingFiles}
+                                isLoadingUser={isLoadingUser}
+                                currentBalance={currentBalance}
+                                remainingBalance={remainingBalance}
+                                selectedFilesCount={selectedFiles.length}
+                                totalPages={totalPages}
+                            />
                         </>
                     ) : (
                         <Box
@@ -352,206 +104,30 @@ export default function StepSend({ onPrev }) {
                                 alignItems: "stretch",
                             }}
                         >
-                            <Paper
-                                elevation={0}
-                                sx={{
-                                    p: 1.5,
-                                    minWidth: 0,
-                                    borderRadius: 3,
-                                    border: "1px solid",
-                                    borderColor: "divider",
-                                    overflow: "hidden",
-                                    height: `${desktopSummaryHeight}px`,
-                                    display: "flex",
-                                    flexDirection: "column",
-                                }}
-                            >
-                                <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={1} sx={{ minWidth: 0 }}>
-                                    <Box sx={{ minWidth: 0, flex: 1 }}>
-                                        <Typography variant="body1" fontWeight={700}>
-                                            Files in this print job
-                                        </Typography>
-                                        <Typography variant="caption" color="text.secondary" sx={{ display: "block", lineHeight: 1.35 }}>
-                                            {`${selectedFiles.length} file${selectedFiles.length === 1 ? "" : "s"} and ${totalPages} printable page${totalPages === 1 ? "" : "s"}.`}
-                                        </Typography>
-                                    </Box>
-                                    <ReceiptLongOutlinedIcon color="action" sx={{ flexShrink: 0 }} />
-                                </Stack>
-
-                                <Box sx={{ mt: 0.9, minWidth: 0, flex: 1, minHeight: 0 }}>
-                                    {isLoadingFiles ? (
-                                        <LoadingList count={selectedIds.length} sx={{ overflowY: "auto", maxHeight: "calc(60vh - 280px)" }} />
-                                    ) : selectedFiles.length === 0 ? (
-                                        <Typography variant="body2" color="text.secondary">
-                                            No files selected
-                                        </Typography>
-                                    ) : (
-                                        <List sx={{ overflowY: "auto", overflowX: "hidden", height: "100%", p: 0, minWidth: 0 }}>
-                                            {selectedFiles.map(file => {
-                                                const opts = printerOptionsByFile[file.id];
-                                                const pagesCount = countPagesInRange(opts?.pageRanges, file.pages) * (opts?.copies || 1);
-                                                return (
-                                                    <ListItem
-                                                        key={file.id}
-                                                        disablePadding
-                                                        sx={{
-                                                            py: 1.15,
-                                                            display: "block",
-                                                            "&:not(:last-child)": {
-                                                                borderBottom: "1px solid",
-                                                                borderColor: "divider",
-                                                            },
-                                                        }}
-                                                    >
-                                                        <ListItemText
-                                                            sx={{ minWidth: 0, m: 0 }}
-                                                            primary={
-                                                                <Typography
-                                                                    variant="body2"
-                                                                    fontWeight={700}
-                                                                    noWrap
-                                                                    sx={{ overflow: "hidden", textOverflow: "ellipsis" }}
-                                                                >
-                                                                    {file.filename}
-                                                                </Typography>
-                                                            }
-                                                            secondary={
-                                                                <Stack direction="row" spacing={0.8} useFlexGap flexWrap="wrap" sx={{ mt: 0.65 }}>
-                                                                    <Chip size="small" variant="outlined" label={`${pagesCount} page${pagesCount === 1 ? "" : "s"}`} sx={{ borderRadius: 999, height: 22, "& .MuiChip-label": { px: 1, fontSize: "0.72rem" } }} />
-                                                                    <Chip size="small" variant="outlined" label={`${opts?.copies || 1} cop${(opts?.copies || 1) === 1 ? "y" : "ies"}`} sx={{ borderRadius: 999, height: 22, "& .MuiChip-label": { px: 1, fontSize: "0.72rem" } }} />
-                                                                    <Chip size="small" variant="outlined" label={opts?.colorMode || "B&W"} sx={{ borderRadius: 999, height: 22, "& .MuiChip-label": { px: 1, fontSize: "0.72rem" } }} />
-                                                                    <Chip size="small" variant="outlined" label={opts?.sides === "1S" ? "One-sided" : "Two-sided"} sx={{ borderRadius: 999, height: 22, "& .MuiChip-label": { px: 1, fontSize: "0.72rem" } }} />
-                                                                </Stack>
-                                                            }
-                                                        />
-                                                    </ListItem>
-                                                );
-                                            })}
-                                        </List>
-                                    )}
-                                </Box>
-                            </Paper>
+                            <FilesListCard
+                                isMobile={false}
+                                height={`${desktopSummaryHeight}px`}
+                                selectedFiles={selectedFiles}
+                                isLoadingFiles={isLoadingFiles}
+                                selectedIds={selectedIds}
+                                printerOptionsByFile={printerOptionsByFile}
+                                totalPages={totalPages}
+                            />
 
                             <Stack spacing={2} sx={{ minWidth: 0, height: `${desktopSummaryHeight}px` }}>
-                                <Paper
-                                    elevation={0}
-                                    sx={{
-                                        p: 1.35,
-                                        minWidth: 0,
-                                        height: 96,
-                                        borderRadius: 3,
-                                        border: "1px solid",
-                                        borderColor: "divider",
-                                        display: "flex",
-                                        flexDirection: "column",
-                                        justifyContent: "center",
-                                    }}
-                                >
-                                    <Stack direction="row" spacing={1.25} alignItems="center" sx={{ minWidth: 0 }}>
-                                        <Box
-                                            sx={{
-                                                width: 38,
-                                                height: 38,
-                                                display: "grid",
-                                                placeItems: "center",
-                                                borderRadius: 2.25,
-                                                backgroundColor: "rgba(25,118,210,0.10)",
-                                                color: "primary.main",
-                                                flexShrink: 0,
-                                            }}
-                                        >
-                                            <PrintIcon />
-                                        </Box>
-                                        <Box sx={{ minWidth: 0 }}>
-                                            <Typography variant="body1" fontWeight={700} noWrap>
-                                                {selectedPrinter?.name}
-                                            </Typography>
-                                            <Typography variant="body2" color="text.secondary" noWrap sx={{ display: "block", overflow: "hidden", textOverflow: "ellipsis" }}>
-                                                {selectedPrinter?.location}
-                                            </Typography>
-                                        </Box>
-                                    </Stack>
-                                </Paper>
-
-                                <Paper
-                                    elevation={0}
-                                    sx={{
-                                        p: 1.75,
-                                        minWidth: 0,
-                                        flex: 1,
-                                        minHeight: 0,
-                                        borderRadius: 3,
-                                        border: "1px solid",
-                                        borderColor: hasEnoughCredit ? "divider" : "error.light",
-                                        backgroundColor: hasEnoughCredit ? "background.paper" : "rgba(211,47,47,0.04)",
-                                        display: "flex",
-                                        flexDirection: "column",
-                                        justifyContent: "space-between",
-                                    }}
-                                >
-                                    <Stack direction="row" spacing={1.25} alignItems="center">
-                                        <Box
-                                            sx={{
-                                                width: 40,
-                                                height: 40,
-                                                display: "grid",
-                                                placeItems: "center",
-                                                borderRadius: 2.5,
-                                                backgroundColor: "rgba(15,23,42,0.06)",
-                                                flexShrink: 0,
-                                            }}
-                                        >
-                                            <AccountBalanceWalletOutlinedIcon />
-                                        </Box>
-                                        <Box sx={{ minWidth: 0 }}>
-                                            <Typography variant="body1" fontWeight={700}>
-                                                Cost summary
-                                            </Typography>
-                                            <Typography variant="caption" color="text.secondary">
-                                                Estimated total before sending the print job.
-                                            </Typography>
-                                        </Box>
-                                    </Stack>
-
-                                    <Box>
-                                        <Typography variant="body2" color="text.secondary">
-                                            Total cost
-                                        </Typography>
-                                        <LoadingTypography
-                                            variant="h4"
-                                            color={hasEnoughCredit ? "primary" : "error"}
-                                            sx={{ fontWeight: 700, lineHeight: 1.15 }}
-                                            loadingWidth={90}
-                                            isLoading={isLoadingFiles}
-                                        >
-                                            €{totalCost.toFixed(2)}
-                                        </LoadingTypography>
-                                    </Box>
-
-                                    <Stack spacing={0.5}>
-                                        <LoadingTypography
-                                            color="text.secondary"
-                                            variant="body2"
-                                            loadingWidth={150}
-                                            isLoading={isLoadingUser}
-                                        >
-                                            {`Current balance: €${currentBalance.toFixed(2)}`}
-                                        </LoadingTypography>
-                                        <Typography variant="body2" color="text.secondary">
-                                            {`Balance after print: €${remainingBalance.toFixed(2)}`}
-                                        </Typography>
-                                        {!hasEnoughCredit && (
-                                            <Typography variant="body2" color="error" fontWeight={600}>
-                                                Insufficient credit. Add funds or adjust the print settings to continue.
-                                            </Typography>
-                                        )}
-                                        {hasEnoughCredit && !allValid && (
-                                            <Typography variant="body2" color="error" fontWeight={600}>
-                                                Fix invalid print options before sending.
-                                            </Typography>
-                                        )}
-                                    </Stack>
-                                </Paper>
+                                <PrinterInfoCard printer={selectedPrinter} isMobile={false} />
+                                <CostSummaryCard
+                                    isMobile={false}
+                                    hasEnoughCredit={hasEnoughCredit}
+                                    allValid={allValid}
+                                    totalCost={totalCost}
+                                    isLoadingFiles={isLoadingFiles}
+                                    isLoadingUser={isLoadingUser}
+                                    currentBalance={currentBalance}
+                                    remainingBalance={remainingBalance}
+                                    selectedFilesCount={selectedFiles.length}
+                                    totalPages={totalPages}
+                                />
                             </Stack>
                         </Box>
                     )}
@@ -559,11 +135,11 @@ export default function StepSend({ onPrev }) {
             </Stack>
 
             <Box sx={{ mt: 2, display: "flex", justifyContent: "space-between" }}>
-                <Button 
-                    variant="outlined" 
-                    onClick={handleBack} 
+                <Button
+                    variant="outlined"
+                    onClick={handleBack}
                     startIcon={<ArrowBackIcon />}
-                    sx={{ borderRadius: 999 }} 
+                    sx={{ borderRadius: 999 }}
                 >
                     Back
                 </Button>

--- a/app/src/components/printComponents/printSteps/StepSend.smoke.test.jsx
+++ b/app/src/components/printComponents/printSteps/StepSend.smoke.test.jsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+// Stable, module-level references — a mock returning fresh object/array
+// literals on every call would make usePrintSummary's effect (which
+// depends on `files`/`printerOptionsByFile`) re-fire every render, looping.
+const selectedPrinter = { name: "Printer1", location: "Room A" };
+const files = [{ id: "f1", filename: "doc.pdf", pages: 10 }];
+const selectedIds = ["f1"];
+const printerOptionsByFile = { f1: { copies: 1, pageRanges: "", colorMode: "B&W", sides: "1S" } };
+const validByFile = {};
+const user = { balance: 10, credit_limit: 0 };
+
+vi.mock("../../../context/PrinterContext", () => ({
+    usePrinter: () => ({ selectedPrinter }),
+}));
+
+vi.mock("../../../context/FileContext", () => ({
+    useFile: () => ({ selectedIds, files, isLoading: false }),
+}));
+
+vi.mock("../../../context/PrintContext", () => ({
+    usePrint: () => ({ printerOptionsByFile, validByFile }),
+}));
+
+vi.mock("../../../context/UserContext", () => ({
+    useUser: () => ({ user, isLoading: false }),
+}));
+
+vi.mock("../../../api/print", () => ({
+    print: vi.fn().mockResolvedValue({}),
+}));
+
+const { default: StepSend } = await import("./StepSend");
+
+describe("StepSend smoke test", () => {
+    it("renders printer info, file list, and cost summary without crashing", () => {
+        render(
+            <MemoryRouter>
+                <StepSend onPrev={() => {}} />
+            </MemoryRouter>
+        );
+
+        expect(screen.getAllByText("Printer1").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("doc.pdf").length).toBeGreaterThan(0);
+        expect(screen.getByRole("button", { name: /send/i })).toBeInTheDocument();
+    });
+});

--- a/app/src/components/utils/ErrorBoundary.test.jsx
+++ b/app/src/components/utils/ErrorBoundary.test.jsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import ErrorBoundary from "./ErrorBoundary";
+
+function Bomb() {
+    throw new Error("boom");
+}
+
+describe("ErrorBoundary", () => {
+    it("renders a fallback instead of crashing when a child throws", () => {
+        const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        render(
+            <ErrorBoundary>
+                <Bomb />
+            </ErrorBoundary>
+        );
+
+        expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /reload/i })).toBeInTheDocument();
+
+        consoleError.mockRestore();
+    });
+
+    it("renders children normally when nothing throws", () => {
+        render(
+            <ErrorBoundary>
+                <div>All good</div>
+            </ErrorBoundary>
+        );
+
+        expect(screen.getByText("All good")).toBeInTheDocument();
+    });
+});

--- a/app/src/hooks/useAsyncAction.js
+++ b/app/src/hooks/useAsyncAction.js
@@ -1,0 +1,24 @@
+import { useState } from "react";
+
+// Factors out the "run an async action, track a loading flag, notify on
+// success/error" pattern that was duplicated across several admin handlers
+// (add/remove member, add/update/remove printer permit). Generic enough to
+// reuse anywhere else the same shape shows up.
+export default function useAsyncAction(fn, { onSuccess, onError } = {}) {
+    const [loading, setLoading] = useState(false);
+
+    const run = async (...args) => {
+        setLoading(true);
+        try {
+            const result = await fn(...args);
+            onSuccess?.(result, ...args);
+            return result;
+        } catch (err) {
+            onError?.(err, ...args);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return [run, loading];
+}

--- a/app/src/hooks/useAsyncAction.test.js
+++ b/app/src/hooks/useAsyncAction.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import useAsyncAction from "./useAsyncAction";
+
+describe("useAsyncAction", () => {
+    it("calls onSuccess and resets loading after a successful run", async () => {
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+        const fn = vi.fn().mockResolvedValue("ok");
+
+        const { result } = renderHook(() => useAsyncAction(fn, { onSuccess, onError }));
+
+        await act(async () => {
+            await result.current[0]("arg1");
+        });
+
+        expect(fn).toHaveBeenCalledWith("arg1");
+        expect(onSuccess).toHaveBeenCalledWith("ok", "arg1");
+        expect(onError).not.toHaveBeenCalled();
+        expect(result.current[1]).toBe(false);
+    });
+
+    it("calls onError and resets loading after a failed run", async () => {
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+        const error = new Error("boom");
+        const fn = vi.fn().mockRejectedValue(error);
+
+        const { result } = renderHook(() => useAsyncAction(fn, { onSuccess, onError }));
+
+        await act(async () => {
+            await result.current[0]();
+        });
+
+        expect(onError).toHaveBeenCalledWith(error);
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(result.current[1]).toBe(false);
+    });
+});

--- a/app/src/hooks/usePrintSummary.js
+++ b/app/src/hooks/usePrintSummary.js
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+import { calculateTotalCost, countPagesInRange } from "../components/printCoreFunctions/calculateCost";
+
+// Owns the "compute a print job summary from the current selection" concern
+// for StepSend — previously a useEffect + inline reduce duplicated across
+// the mobile/desktop render branches.
+export default function usePrintSummary(files, selectedIds, printerOptionsByFile, selectedPrinter) {
+    const [selectedFiles, setSelectedFiles] = useState([]);
+    const [totalCost, setTotalCost] = useState(0);
+
+    useEffect(() => {
+        const current = files?.filter(f => selectedIds.includes(f.id)) || [];
+        setSelectedFiles(current);
+        setTotalCost(calculateTotalCost(current, printerOptionsByFile, selectedPrinter));
+    }, [files, selectedIds, printerOptionsByFile, selectedPrinter]);
+
+    const totalPages = selectedFiles.reduce((sum, file) => {
+        const opts = printerOptionsByFile[file.id];
+        return sum + countPagesInRange(opts?.pageRanges, file.pages) * (opts?.copies || 1);
+    }, 0);
+
+    return { selectedFiles, totalCost, totalPages };
+}

--- a/app/src/hooks/useStatisticsData.js
+++ b/app/src/hooks/useStatisticsData.js
@@ -1,0 +1,81 @@
+function shortLabel(label, maxLen = 14) {
+    if (!label) return "";
+    return label.length > maxLen ? label.slice(0, maxLen - 1) + "…" : label;
+}
+
+function shortLabelMobile(label, maxLen = 9) {
+    if (!label) return "";
+    return label.length > maxLen ? label.slice(0, maxLen - 1) + "…" : label;
+}
+
+// Owns the derived chart/table data and finance breakdown math for
+// AdminStatisticsPage, so the page component itself is just fetch + compose.
+export default function useStatisticsData(stats, allPrinters, isMobile) {
+    const labelFn = isMobile ? shortLabelMobile : shortLabel;
+
+    const statsByPrinterName = Object.fromEntries(
+        (stats?.by_printer ?? []).map((p) => [p.printer_name, p])
+    );
+
+    const printerChartData = allPrinters.map((p) => {
+        const s = statsByPrinterName[p.name];
+        return {
+            name: labelFn(p.name),
+            fullName: p.name,
+            "B/W": s?.bw_pages ?? 0,
+            Color: s?.color_pages ?? 0,
+        };
+    });
+
+    const printerRevenueChartData = allPrinters.map((p) => {
+        const s = statsByPrinterName[p.name];
+        return {
+            name: labelFn(p.name),
+            fullName: p.name,
+            Revenue: s?.total_cost ?? 0,
+        };
+    });
+
+    const topUserChartData = (stats?.by_user ?? []).slice(0, 10).map((u) => ({
+        name: labelFn(u.username),
+        fullName: u.username,
+        "B/W": u.bw_pages,
+        Color: u.color_pages,
+    }));
+
+    const f = stats?.finance ?? {};
+    const adjustmentsPositive = (f.total_adjustments ?? 0) >= 0;
+    const computedSum = (f.total_current_balance ?? 0)
+        + (f.total_spent_on_print ?? 0)
+        - (f.total_refunded ?? 0)
+        - (f.total_adjustments ?? 0);
+    const discrepancy = Math.abs((f.total_recharged ?? 0) - computedSum) > 0.02;
+
+    const printerRows = (stats?.by_printer ?? []).map((p) => ({
+        key: p.printer_name,
+        name: p.printer_name,
+        total_pages: p.total_pages,
+        bw_pages: p.bw_pages,
+        color_pages: p.color_pages,
+        total_sheets: p.total_sheets,
+        total_cost: p.total_cost,
+    }));
+
+    const userRows = (stats?.by_user ?? []).map((u) => ({
+        key: u.user_id,
+        name: u.username,
+        total_pages: u.total_pages,
+        bw_pages: u.bw_pages,
+        color_pages: u.color_pages,
+        total_sheets: u.total_sheets,
+    }));
+
+    return {
+        printerChartData,
+        printerRevenueChartData,
+        topUserChartData,
+        finance: { f, adjustmentsPositive, discrepancy },
+        printerRows,
+        userRows,
+    };
+}

--- a/app/src/hooks/useSubmitPrint.js
+++ b/app/src/hooks/useSubmitPrint.js
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useSnackbar } from "notistack";
+
+import { print } from "../api/print";
+
+// Owns the sequential submit-with-per-file-snackbars flow for StepSend,
+// decoupled from rendering.
+export default function useSubmitPrint({ selectedIds, selectedPrinter, printerOptionsByFile, selectedFiles }) {
+    const [isPrinting, setIsPrinting] = useState(false);
+    const navigate = useNavigate();
+    const { enqueueSnackbar } = useSnackbar();
+
+    const handlePrint = async () => {
+        setIsPrinting(true);
+
+        const printStatus = {};
+
+        for (let i = 0; i < selectedIds.length; i++) {
+            const id = selectedIds[i];
+            printStatus[id] = { status: false, message: "" };
+
+            try {
+                await print(selectedPrinter.name, id, printerOptionsByFile[id]);
+                printStatus[id].status = true;
+            } catch (err) {
+                printStatus[id].message = err.message;
+            }
+        }
+
+        const filesMap = Object.fromEntries(selectedFiles.map(obj => [obj.id, obj]));
+        setTimeout(() => {
+            setIsPrinting(false);
+
+            for (const key in printStatus) {
+                const status = printStatus[key].status;
+                if (status) {
+                    enqueueSnackbar(`File ${filesMap[key].filename} queued`, { variant: "success" });
+                } else {
+                    enqueueSnackbar(`Could not print ${filesMap[key].filename}. Try again later.`, { variant: "error" });
+                }
+            }
+
+            navigate("/");
+        }, 800);
+    };
+
+    return { isPrinting, handlePrint };
+}

--- a/app/src/test-setup.js
+++ b/app/src/test-setup.js
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/app/src/views/AdminStatisticsPage.jsx
+++ b/app/src/views/AdminStatisticsPage.jsx
@@ -2,16 +2,8 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
     Box,
     Button,
-    Card,
-    CardContent,
     Skeleton,
     Stack,
-    Table,
-    TableBody,
-    TableCell,
-    TableContainer,
-    TableHead,
-    TableRow,
     Typography,
     useMediaQuery,
 } from "@mui/material";
@@ -26,250 +18,20 @@ import TuneIcon from "@mui/icons-material/Tune";
 import AccountBalanceWalletIcon from "@mui/icons-material/AccountBalanceWallet";
 import AssignmentReturnIcon from "@mui/icons-material/AssignmentReturn";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
-import {
-    BarChart,
-    Bar,
-    XAxis,
-    YAxis,
-    CartesianGrid,
-    Tooltip,
-    Legend,
-    ResponsiveContainer,
-} from "recharts";
 
 import { getStatsOverview } from "../api/stats";
 import { getPrinters } from "../api/printer";
 import AdminPageHero from "../components/adminComponents/AdminPageHero";
 import AdminSurface from "../components/adminComponents/AdminSurface";
-
-
-// ─── Constants ────────────────────────────────────────────────────────────────
+import StatCard from "../components/adminComponents/StatCard";
+import FinanceBreakdownItem from "../components/adminComponents/FinanceBreakdownItem";
+import StatsBarChart from "../components/adminComponents/StatsBarChart";
+import StatsBreakdownTable from "../components/adminComponents/StatsBreakdownTable";
+import useStatisticsData from "../hooks/useStatisticsData";
 
 const BW_COLOR = "#78909c";
 const COLOR_COLOR = "#ed6c02";
-
-function shortLabel(label, maxLen = 14) {
-    if (!label) return "";
-    return label.length > maxLen ? label.slice(0, maxLen - 1) + "…" : label;
-}
-
-function shortLabelMobile(label, maxLen = 9) {
-    if (!label) return "";
-    return label.length > maxLen ? label.slice(0, maxLen - 1) + "…" : label;
-}
-
-
-// ─── Sub-components ───────────────────────────────────────────────────────────
-
-function StatCard({ icon, label, value, accentColor, loading, subtitle }) {
-    return (
-        <Card
-            elevation={0}
-            sx={{
-                height: "100%",
-                borderRadius: 3,
-                border: "1px solid",
-                borderColor: "divider",
-                background: "linear-gradient(180deg, rgba(255,255,255,0.98) 0%, rgba(248,250,252,0.96) 100%)",
-                boxShadow: "0 14px 34px rgba(15, 23, 42, 0.08)"
-            }}
-        >
-            <CardContent sx={{ p: { xs: 1.5, sm: 2 }, "&:last-child": { pb: { xs: 1.5, sm: 2 } } }}>
-                <Stack direction="row" alignItems="center" spacing={1} mb={1}>
-                    <Box
-                        sx={{
-                            p: { xs: 0.75, sm: 1 },
-                            borderRadius: 2,
-                            backgroundColor: `${accentColor}22`,
-                            color: accentColor,
-                            display: "flex",
-                            alignItems: "center",
-                            flexShrink: 0,
-                        }}
-                    >
-                        {icon}
-                    </Box>
-                    <Typography
-                        variant="body2"
-                        color="text.secondary"
-                        lineHeight={1.3}
-                        sx={{ fontSize: { xs: "0.72rem", sm: "0.875rem" } }}
-                    >
-                        {label}
-                    </Typography>
-                </Stack>
-                {loading ? (
-                    <Skeleton width="55%" height={36} />
-                ) : (
-                    <Typography
-                        fontWeight="bold"
-                        sx={{ fontSize: { xs: "1.4rem", sm: "1.75rem", md: "2.125rem" } }}
-                    >
-                        {value}
-                    </Typography>
-                )}
-                {subtitle && (
-                    <Typography
-                        variant="caption"
-                        color="text.disabled"
-                        sx={{ display: { xs: "none", sm: "block" } }}
-                    >
-                        {subtitle}
-                    </Typography>
-                )}
-            </CardContent>
-        </Card>
-    );
-}
-
-function FinanceBreakdownItem({ icon, label, value, color, subtitle, loading }) {
-    return (
-        <Box
-            sx={{
-                p: { xs: 1.5, sm: 2 },
-                borderRadius: 2,
-                border: "1px solid",
-                borderColor: "divider",
-                flex: 1,
-                minWidth: 0,
-            }}
-        >
-            <Stack direction="row" alignItems="center" spacing={0.7} mb={0.5}>
-                <Box sx={{ color, display: "flex", alignItems: "center", flexShrink: 0 }}>{icon}</Box>
-                <Typography
-                    variant="body2"
-                    color="text.secondary"
-                    sx={{ fontSize: { xs: "0.7rem", sm: "0.8rem" }, lineHeight: 1.3 }}
-                >
-                    {label}
-                </Typography>
-            </Stack>
-            {loading ? (
-                <Skeleton width="65%" height={26} />
-            ) : (
-                <Typography
-                    fontWeight="bold"
-                    color={color}
-                    sx={{ fontSize: { xs: "1rem", sm: "1.3rem" } }}
-                >
-                    {value}
-                </Typography>
-            )}
-            {subtitle && (
-                <Typography
-                    variant="caption"
-                    color="text.disabled"
-                    sx={{ display: { xs: "none", sm: "block" } }}
-                >
-                    {subtitle}
-                </Typography>
-            )}
-        </Box>
-    );
-}
-
-function SkeletonRows({ cols, rows = 4 }) {
-    return Array.from({ length: rows }).map((_, i) => (
-        <TableRow key={i}>
-            {Array.from({ length: cols }).map((_, j) => (
-                <TableCell key={j}>
-                    <Skeleton />
-                </TableCell>
-            ))}
-        </TableRow>
-    ));
-}
-
-// Horizontal bar chart used on mobile (readable with long category names)
-function ResponsiveBarChart({ data, height, isMobile }) {
-    if (isMobile) {
-        // Horizontal layout: category on Y axis, values on X axis
-        const mobileData = data.map((d) => ({ ...d, name: shortLabelMobile(d.fullName) }));
-        const barSize = Math.max(10, Math.min(20, Math.floor(220 / (data.length || 1))));
-        return (
-            <ResponsiveContainer width="100%" height={Math.max(height, data.length * 44 + 60)}>
-                <BarChart
-                    data={mobileData}
-                    layout="vertical"
-                    margin={{ top: 5, right: 16, left: 4, bottom: 5 }}
-                >
-                    <CartesianGrid strokeDasharray="3 3" horizontal={false} />
-                    <XAxis type="number" tick={{ fontSize: 11 }} allowDecimals={false} />
-                    <YAxis type="category" dataKey="name" tick={{ fontSize: 11 }} width={72} />
-                    <Tooltip
-                        formatter={(value, name) => [value.toLocaleString(), name]}
-                        labelFormatter={(_, payload) => payload?.[0]?.payload?.fullName ?? ""}
-                    />
-                    <Legend wrapperStyle={{ fontSize: 12 }} />
-                    <Bar dataKey="B/W" fill={BW_COLOR} radius={[0, 3, 3, 0]} barSize={barSize} />
-                    <Bar dataKey="Color" fill={COLOR_COLOR} radius={[0, 3, 3, 0]} barSize={barSize} />
-                </BarChart>
-            </ResponsiveContainer>
-        );
-    }
-
-    return (
-        <ResponsiveContainer width="100%" height={height}>
-            <BarChart data={data} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="name" tick={{ fontSize: 12 }} />
-                <YAxis tick={{ fontSize: 12 }} allowDecimals={false} />
-                <Tooltip
-                    formatter={(value, name) => [value.toLocaleString(), name]}
-                    labelFormatter={(_, payload) => payload?.[0]?.payload?.fullName ?? ""}
-                />
-                <Legend />
-                <Bar dataKey="B/W" fill={BW_COLOR} radius={[3, 3, 0, 0]} />
-                <Bar dataKey="Color" fill={COLOR_COLOR} radius={[3, 3, 0, 0]} />
-            </BarChart>
-        </ResponsiveContainer>
-    );
-}
-
-
-function RevenueBarChart({ data, height, isMobile }) {
-    const fmtEuro = (v) => `€${v.toFixed(2)}`;
-    if (isMobile) {
-        const mobileData = data.map((d) => ({ ...d, name: shortLabelMobile(d.fullName) }));
-        const barSize = Math.max(10, Math.min(20, Math.floor(220 / (data.length || 1))));
-        return (
-            <ResponsiveContainer width="100%" height={Math.max(height, data.length * 44 + 60)}>
-                <BarChart
-                    data={mobileData}
-                    layout="vertical"
-                    margin={{ top: 5, right: 16, left: 4, bottom: 5 }}
-                >
-                    <CartesianGrid strokeDasharray="3 3" horizontal={false} />
-                    <XAxis type="number" tick={{ fontSize: 11 }} tickFormatter={fmtEuro} />
-                    <YAxis type="category" dataKey="name" tick={{ fontSize: 11 }} width={72} />
-                    <Tooltip
-                        formatter={(value) => [`€${value.toFixed(2)}`, "Revenue"]}
-                        labelFormatter={(_, payload) => payload?.[0]?.payload?.fullName ?? ""}
-                    />
-                    <Bar dataKey="Revenue" fill="#2e7d32" radius={[0, 3, 3, 0]} barSize={barSize} />
-                </BarChart>
-            </ResponsiveContainer>
-        );
-    }
-
-    return (
-        <ResponsiveContainer width="100%" height={height}>
-            <BarChart data={data} margin={{ top: 5, right: 10, left: 10, bottom: 5 }}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="name" tick={{ fontSize: 12 }} />
-                <YAxis tick={{ fontSize: 12 }} tickFormatter={fmtEuro} />
-                <Tooltip
-                    formatter={(value) => [`€${value.toFixed(2)}`, "Revenue"]}
-                    labelFormatter={(_, payload) => payload?.[0]?.payload?.fullName ?? ""}
-                />
-                <Bar dataKey="Revenue" fill="#2e7d32" radius={[3, 3, 0, 0]} />
-            </BarChart>
-        </ResponsiveContainer>
-    );
-}
-
-
-// ─── Main page ────────────────────────────────────────────────────────────────
+const euroFormatter = (v) => `€${v.toFixed(2)}`;
 
 export default function AdminStatisticsPage() {
     const theme = useTheme();
@@ -293,47 +55,14 @@ export default function AdminStatisticsPage() {
 
     const refresh = () => queryClient.invalidateQueries({ queryKey: ["admin-stats"] });
 
-    const labelFn = isMobile ? shortLabelMobile : shortLabel;
-
-    const statsByPrinterName = Object.fromEntries(
-        (stats?.by_printer ?? []).map((p) => [p.printer_name, p])
-    );
-
-    const printerChartData = allPrinters.map((p) => {
-        const s = statsByPrinterName[p.name];
-        return {
-            name: labelFn(p.name),
-            fullName: p.name,
-            "B/W": s?.bw_pages ?? 0,
-            Color: s?.color_pages ?? 0,
-        };
-    });
-
-    const printerRevenueChartData = allPrinters.map((p) => {
-        const s = statsByPrinterName[p.name];
-        return {
-            name: labelFn(p.name),
-            fullName: p.name,
-            Revenue: s?.total_cost ?? 0,
-        };
-    });
-
-    const topUserChartData = (stats?.by_user ?? []).slice(0, 10).map((u) => ({
-        name: labelFn(u.username),
-        fullName: u.username,
-        "B/W": u.bw_pages,
-        Color: u.color_pages,
-    }));
-
-    const finance = stats?.finance;
-    const f = finance ?? {};
-    const adjustmentsPositive = (f.total_adjustments ?? 0) >= 0;
-
-    const computedSum = (f.total_current_balance ?? 0)
-        + (f.total_spent_on_print ?? 0)
-        - (f.total_refunded ?? 0)
-        - (f.total_adjustments ?? 0);
-    const discrepancy = Math.abs((f.total_recharged ?? 0) - computedSum) > 0.02;
+    const {
+        printerChartData,
+        printerRevenueChartData,
+        topUserChartData,
+        finance: { f, adjustmentsPositive, discrepancy },
+        printerRows,
+        userRows,
+    } = useStatisticsData(stats, allPrinters, isMobile);
 
     const chartHeight = isMobile ? 220 : 260;
 
@@ -507,10 +236,12 @@ export default function AdminStatisticsPage() {
                             No print data available.
                         </Typography>
                     ) : (
-                        <ResponsiveBarChart
+                        <StatsBarChart
                             data={printerChartData}
                             height={chartHeight}
                             isMobile={isMobile}
+                            series={[{ dataKey: "B/W", color: BW_COLOR }, { dataKey: "Color", color: COLOR_COLOR }]}
+                            allowDecimals={false}
                         />
                     )}
                 </AdminSurface>
@@ -524,10 +255,12 @@ export default function AdminStatisticsPage() {
                             No print data available.
                         </Typography>
                     ) : (
-                        <ResponsiveBarChart
+                        <StatsBarChart
                             data={topUserChartData}
                             height={chartHeight}
                             isMobile={isMobile}
+                            series={[{ dataKey: "B/W", color: BW_COLOR }, { dataKey: "Color", color: COLOR_COLOR }]}
+                            allowDecimals={false}
                         />
                     )}
                 </AdminSurface>
@@ -541,10 +274,15 @@ export default function AdminStatisticsPage() {
                             No print data available.
                         </Typography>
                     ) : (
-                        <RevenueBarChart
+                        <StatsBarChart
                             data={printerRevenueChartData}
                             height={chartHeight}
                             isMobile={isMobile}
+                            series={[{ dataKey: "Revenue", color: "#2e7d32" }]}
+                            valueFormatter={euroFormatter}
+                            tickFormatter={euroFormatter}
+                            showLegend={false}
+                            desktopMargin={{ top: 5, right: 10, left: 10, bottom: 5 }}
                         />
                     )}
                 </AdminSurface>
@@ -552,104 +290,23 @@ export default function AdminStatisticsPage() {
 
             {/* ── Printer table ── */}
             <AdminSurface title="Pages per Printer" sx={{ p: { xs: 2, sm: 3 } }}>
-                <TableContainer sx={{ overflowX: "auto" }}>
-                    <Table size="small" sx={{ minWidth: 300 }}>
-                        <TableHead>
-                            <TableRow>
-                                <TableCell><b>Printer</b></TableCell>
-                                <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
-                                    <b>{isMobile ? "Total" : "Total Pages"}</b>
-                                </TableCell>
-                                <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
-                                    <b>B/W</b>
-                                </TableCell>
-                                <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
-                                    <b>{isMobile ? "Color" : "Color Pages"}</b>
-                                </TableCell>
-                                <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
-                                    <b>Sheets</b>
-                                </TableCell>
-                                <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
-                                    <b>Revenue</b>
-                                </TableCell>
-                            </TableRow>
-                        </TableHead>
-                        <TableBody>
-                            {isLoading ? (
-                                <SkeletonRows cols={6} rows={3} />
-                            ) : (stats?.by_printer ?? []).length === 0 ? (
-                                <TableRow>
-                                    <TableCell colSpan={6}>
-                                        <Typography color="text.secondary">No data available.</Typography>
-                                    </TableCell>
-                                </TableRow>
-                            ) : (
-                                (stats?.by_printer ?? []).map((p) => (
-                                    <TableRow key={p.printer_name} hover>
-                                        <TableCell sx={{ maxWidth: { xs: 110, sm: "none" }, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                                            {p.printer_name}
-                                        </TableCell>
-                                        <TableCell align="right">{p.total_pages.toLocaleString()}</TableCell>
-                                        <TableCell align="right">{p.bw_pages.toLocaleString()}</TableCell>
-                                        <TableCell align="right">{p.color_pages.toLocaleString()}</TableCell>
-                                        <TableCell align="right">{p.total_sheets.toLocaleString()}</TableCell>
-                                        <TableCell align="right" sx={{ fontWeight: "bold", color: "success.dark" }}>
-                                            €{p.total_cost.toFixed(2)}
-                                        </TableCell>
-                                    </TableRow>
-                                ))
-                            )}
-                        </TableBody>
-                    </Table>
-                </TableContainer>
+                <StatsBreakdownTable
+                    nameHeader="Printer"
+                    rows={printerRows}
+                    isLoading={isLoading}
+                    isMobile={isMobile}
+                    showRevenue
+                />
             </AdminSurface>
 
             {/* ── User table ── */}
             <AdminSurface title="Pages per User" sx={{ p: { xs: 2, sm: 3 } }}>
-                <TableContainer sx={{ overflowX: "auto" }}>
-                    <Table size="small" sx={{ minWidth: 300 }}>
-                        <TableHead>
-                            <TableRow>
-                                <TableCell><b>Username</b></TableCell>
-                                <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
-                                    <b>{isMobile ? "Total" : "Total Pages"}</b>
-                                </TableCell>
-                                <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
-                                    <b>B/W</b>
-                                </TableCell>
-                                <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
-                                    <b>{isMobile ? "Color" : "Color Pages"}</b>
-                                </TableCell>
-                                <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
-                                    <b>Sheets</b>
-                                </TableCell>
-                            </TableRow>
-                        </TableHead>
-                        <TableBody>
-                            {isLoading ? (
-                                <SkeletonRows cols={5} rows={5} />
-                            ) : (stats?.by_user ?? []).length === 0 ? (
-                                <TableRow>
-                                    <TableCell colSpan={5}>
-                                        <Typography color="text.secondary">No data available.</Typography>
-                                    </TableCell>
-                                </TableRow>
-                            ) : (
-                                (stats?.by_user ?? []).map((u) => (
-                                    <TableRow key={u.user_id} hover>
-                                        <TableCell sx={{ maxWidth: { xs: 100, sm: "none" }, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                                            {u.username}
-                                        </TableCell>
-                                        <TableCell align="right">{u.total_pages.toLocaleString()}</TableCell>
-                                        <TableCell align="right">{u.bw_pages.toLocaleString()}</TableCell>
-                                        <TableCell align="right">{u.color_pages.toLocaleString()}</TableCell>
-                                        <TableCell align="right">{u.total_sheets.toLocaleString()}</TableCell>
-                                    </TableRow>
-                                ))
-                            )}
-                        </TableBody>
-                    </Table>
-                </TableContainer>
+                <StatsBreakdownTable
+                    nameHeader="Username"
+                    rows={userRows}
+                    isLoading={isLoading}
+                    isMobile={isMobile}
+                />
             </AdminSurface>
 
         </Box>

--- a/app/src/views/AdminStatisticsPage.smoke.test.jsx
+++ b/app/src/views/AdminStatisticsPage.smoke.test.jsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("../api/stats", () => ({
+    getStatsOverview: vi.fn().mockResolvedValue({
+        total_pages: 100,
+        bw_pages: 60,
+        color_pages: 40,
+        total_sheets: 80,
+        total_jobs: 10,
+        by_printer: [
+            { printer_name: "Printer1", total_pages: 100, bw_pages: 60, color_pages: 40, total_sheets: 80, total_cost: 12.5 },
+        ],
+        by_user: [
+            { user_id: "u1", username: "alice", total_pages: 100, bw_pages: 60, color_pages: 40, total_sheets: 80 },
+        ],
+        finance: {
+            total_recharged: 50,
+            total_current_balance: 20,
+            total_spent_on_print: 12.5,
+            total_refunded: 0,
+            total_adjustments: 0,
+        },
+    }),
+}));
+
+vi.mock("../api/printer", () => ({
+    getPrinters: vi.fn().mockResolvedValue([{ id: "p1", name: "Printer1" }]),
+}));
+
+const { default: AdminStatisticsPage } = await import("./AdminStatisticsPage");
+
+function renderWithClient(ui) {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+describe("AdminStatisticsPage smoke test", () => {
+    it("renders cards, charts, and tables without crashing", async () => {
+        renderWithClient(<AdminStatisticsPage />);
+
+        await waitFor(() => expect(screen.getAllByText("Total Pages").length).toBeGreaterThan(0));
+        await waitFor(() => expect(screen.getAllByText("Printer1").length).toBeGreaterThan(0));
+        expect(screen.getAllByText("alice").length).toBeGreaterThan(0);
+    });
+});

--- a/app/src/views/AdminUsersPage.jsx
+++ b/app/src/views/AdminUsersPage.jsx
@@ -1,37 +1,7 @@
 import { useState } from "react";
-import {
-    Box,
-    Button,
-    Chip,
-    Dialog,
-    DialogActions,
-    DialogContent,
-    DialogContentText,
-    DialogTitle,
-    IconButton,
-    InputAdornment,
-    Paper,
-    Skeleton,
-    Table,
-    TableBody,
-    TableCell,
-    TableContainer,
-    TableHead,
-    TableRow,
-    TextField,
-    Tooltip,
-    Typography,
-    useMediaQuery
-} from "@mui/material";
+import { Box, Button, useMediaQuery } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
-import EditIcon from "@mui/icons-material/Edit";
-import AccountBalanceWalletIcon from "@mui/icons-material/AccountBalanceWallet";
-import ReceiptLongIcon from "@mui/icons-material/ReceiptLong";
 import RefreshIcon from "@mui/icons-material/Refresh";
-import SearchIcon from "@mui/icons-material/Search";
-import ClearIcon from "@mui/icons-material/Clear";
-import DeleteIcon from "@mui/icons-material/Delete";
-import CloseIcon from "@mui/icons-material/Close";
 import { useSnackbar } from "notistack";
 
 import { useAdmin } from "../context/AdminContext";
@@ -40,6 +10,8 @@ import RechargeModal from "../components/adminComponents/RechargeModal";
 import UserTransactionsModal from "../components/adminComponents/UserTransactionsModal";
 import AdminPageHero from "../components/adminComponents/AdminPageHero";
 import AdminSurface from "../components/adminComponents/AdminSurface";
+import UsersTable from "../components/adminComponents/UsersTable";
+import ConfirmDeleteUserDialog from "../components/adminComponents/ConfirmDeleteUserDialog";
 
 
 export default function AdminUsersPage() {
@@ -60,9 +32,7 @@ export default function AdminUsersPage() {
     const [editUser, setEditUser] = useState(null);
     const [rechargeUser, setRechargeUser] = useState(null);
     const [txUser, setTxUser] = useState(null);
-    const [selectedUser, setSelectedUser] = useState(null); // mobile action sheet
     const [confirmDeleteUser, setConfirmDeleteUser] = useState(null);
-    const [search, setSearch] = useState("");
 
     const handleSaveEdit = async (userId, data) => {
         await updateUser(userId, data);
@@ -91,24 +61,6 @@ export default function AdminUsersPage() {
         }
     };
 
-    const skeletonRows = Array.from({ length: 6 });
-
-    const filteredUsers = (users ?? [])
-        .filter((u) => {
-            const q = search.trim().toLowerCase();
-            if (!q) return true;
-            return (
-                u.username?.toLowerCase().includes(q) ||
-                u.name?.toLowerCase().includes(q) ||
-                u.surname?.toLowerCase().includes(q) ||
-                `${u.name} ${u.surname}`.toLowerCase().includes(q)
-            );
-        })
-        .sort((a, b) => {
-            if (a.is_admin !== b.is_admin) return a.is_admin ? -1 : 1;
-            return (a.username ?? "").localeCompare(b.username ?? "");
-        });
-
     return (
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2.25 }}>
             <AdminPageHero
@@ -129,248 +81,16 @@ export default function AdminUsersPage() {
             />
 
             <AdminSurface title="User Directory" description="Search users and open account actions directly from the list.">
-                <TextField
-                    placeholder="Search by name or username…"
-                    value={search}
-                    onChange={(e) => setSearch(e.target.value)}
-                    size="small"
-                    fullWidth
-                    slotProps={{
-                        input: {
-                            startAdornment: (
-                                <InputAdornment position="start">
-                                    <SearchIcon fontSize="small" />
-                                </InputAdornment>
-                            ),
-                            endAdornment: search ? (
-                                <InputAdornment position="end">
-                                    <IconButton size="small" onClick={() => setSearch("")} aria-label="Clear search">
-                                        <ClearIcon fontSize="small" />
-                                    </IconButton>
-                                </InputAdornment>
-                            ) : null
-                        }
-                    }}
+                <UsersTable
+                    users={users}
+                    usersLoading={usersLoading}
+                    isMobile={isMobile}
+                    onEditUser={setEditUser}
+                    onRechargeUser={setRechargeUser}
+                    onViewTransactions={setTxUser}
+                    onDeleteUser={setConfirmDeleteUser}
                 />
-
-                <TableContainer
-                    component={Paper}
-                    elevation={0}
-                    sx={{
-                        maxHeight: "calc(80vh - 180px)",
-                        overflowY: "auto",
-                        borderRadius: 2.5,
-                        border: "1px solid",
-                        borderColor: "divider",
-                        boxShadow: "none",
-                        bgcolor: "rgba(255,255,255,0.75)"
-                    }}
-                >
-                <Table size="small">
-                    <TableHead>
-                        <TableRow>
-                            {isMobile ? (
-                                <>
-                                    <TableCell>User</TableCell>
-                                    <TableCell align="right">Balance</TableCell>
-                                </>
-                            ) : (
-                                <>
-                                    <TableCell>Username</TableCell>
-                                    <TableCell>Name</TableCell>
-                                    <TableCell>Email</TableCell>
-                                    <TableCell>Balance</TableCell>
-                                    <TableCell>Roles</TableCell>
-                                    <TableCell align="right">Actions</TableCell>
-                                </>
-                            )}
-                        </TableRow>
-                    </TableHead>
-                    <TableBody>
-                        {usersLoading
-                            ? skeletonRows.map((_, i) => (
-                                <TableRow key={i}>
-                                    <TableCell colSpan={isMobile ? 2 : 6}><Skeleton /></TableCell>
-                                </TableRow>
-                            ))
-                            : !users?.length
-                            ? (
-                                <TableRow>
-                                    <TableCell colSpan={isMobile ? 2 : 6} align="center">
-                                        <Typography variant="body2" color="text.secondary">
-                                            No users found.
-                                        </Typography>
-                                    </TableCell>
-                                </TableRow>
-                            )
-                            : filteredUsers.length === 0 ? (
-                                <TableRow>
-                                    <TableCell colSpan={isMobile ? 2 : 6} align="center">
-                                        <Typography variant="body2" color="text.secondary">
-                                            No users match your search.
-                                        </Typography>
-                                    </TableCell>
-                                </TableRow>
-                            ) : filteredUsers.map((user) => isMobile ? (
-                                <TableRow
-                                    key={user.id}
-                                    hover
-                                    onClick={() => setSelectedUser(user)}
-                                    sx={{ cursor: "pointer" }}
-                                >
-                                    <TableCell>
-                                        <Typography variant="body2" fontWeight="medium">
-                                            {user.username}
-                                        </Typography>
-                                        <Typography variant="caption" color="text.secondary">
-                                            {user.name} {user.surname}
-                                        </Typography>
-                                    </TableCell>
-                                    <TableCell align="right">
-                                        <Typography
-                                            variant="body2"
-                                            fontWeight="medium"
-                                            color={user.balance < 0 ? "error.main" : "success.main"}
-                                        >
-                                            €{user.balance?.toFixed(2)}
-                                        </Typography>
-                                        <Box display="flex" gap={0.5} justifyContent="flex-end" mt={0.25}>
-                                            {user.is_admin && <Chip label="Admin" color="primary" size="small" />}
-                                            {!user.is_active && <Chip label="Inactive" color="error" size="small" />}
-                                        </Box>
-                                    </TableCell>
-                                </TableRow>
-                            ) : (
-                                <TableRow
-                                    key={user.id}
-                                    hover
-                                    onClick={() => setSelectedUser(user)}
-                                    sx={{ cursor: "pointer" }}
-                                >
-                                    <TableCell>
-                                        <Typography variant="body2" fontWeight="medium">
-                                            {user.username}
-                                        </Typography>
-                                    </TableCell>
-                                    <TableCell>{user.name} {user.surname}</TableCell>
-                                    <TableCell>{user.email}</TableCell>
-                                    <TableCell>
-                                        <Typography
-                                            variant="body2"
-                                            color={user.balance < 0 ? "error.main" : "text.primary"}
-                                        >
-                                            €{user.balance?.toFixed(2)}
-                                        </Typography>
-                                    </TableCell>
-                                    <TableCell>
-                                        <Box display="flex" gap={0.5}>
-                                            {user.is_admin && <Chip label="Admin" color="primary" size="small" />}
-                                            {!user.is_active && <Chip label="Inactive" color="error" size="small" />}
-                                        </Box>
-                                    </TableCell>
-                                    <TableCell align="right">
-                                        <Tooltip title="Edit user info">
-                                            <IconButton size="small" onClick={(e) => { e.stopPropagation(); setEditUser(user); }} aria-label="Edit user info">
-                                                <EditIcon fontSize="small" />
-                                            </IconButton>
-                                        </Tooltip>
-                                        <Tooltip title="Adjust balance">
-                                            <IconButton size="small" onClick={(e) => { e.stopPropagation(); setRechargeUser(user); }} aria-label="Adjust balance">
-                                                <AccountBalanceWalletIcon fontSize="small" />
-                                            </IconButton>
-                                        </Tooltip>
-                                        <Tooltip title="View transactions">
-                                            <IconButton size="small" onClick={(e) => { e.stopPropagation(); setTxUser(user); }} aria-label="View transactions">
-                                                <ReceiptLongIcon fontSize="small" />
-                                            </IconButton>
-                                        </Tooltip>
-                                        <Tooltip title="Delete user">
-                                            <IconButton size="small" color="error" onClick={(e) => { e.stopPropagation(); setConfirmDeleteUser(user); }} aria-label="Delete user">
-                                                <DeleteIcon fontSize="small" />
-                                            </IconButton>
-                                        </Tooltip>
-                                    </TableCell>
-                                </TableRow>
-                            ))
-                        }
-                    </TableBody>
-                </Table>
-                </TableContainer>
             </AdminSurface>
-
-            {/* Mobile action sheet */}
-            <Dialog
-                open={Boolean(selectedUser)}
-                onClose={() => setSelectedUser(null)}
-                fullWidth
-                maxWidth="xs"
-            >
-                <DialogTitle sx={{ pb: 0.5, pr: 6 }}>
-                    <Typography fontWeight="bold">{selectedUser?.username}</Typography>
-                    <Typography variant="body2" color="text.secondary">
-                        {selectedUser?.name} {selectedUser?.surname}
-                    </Typography>
-                    <IconButton
-                        onClick={() => setSelectedUser(null)}
-                        size="small"
-                        sx={{ position: "absolute", top: 8, right: 8 }}
-                        aria-label="Close"
-                    >
-                        <CloseIcon fontSize="small" />
-                    </IconButton>
-                </DialogTitle>
-                <DialogContent>
-                    <Typography variant="body2" color="text.secondary" gutterBottom>
-                        {selectedUser?.email}
-                    </Typography>
-                    <Box display="flex" alignItems="center" gap={1} mt={0.5}>
-                        <Typography
-                            variant="body1"
-                            fontWeight="medium"
-                            color={selectedUser?.balance < 0 ? "error.main" : "success.main"}
-                        >
-                            €{selectedUser?.balance?.toFixed(2)}
-                        </Typography>
-                        {selectedUser?.is_admin && <Chip label="Admin" color="primary" size="small" />}
-                        {!selectedUser?.is_active && <Chip label="Inactive" color="error" size="small" />}
-                    </Box>
-                </DialogContent>
-                <Box sx={{ display: "flex", flexDirection: "column", gap: 1, px: 2, pb: 2 }}>
-                    <Button
-                        fullWidth
-                        variant="outlined"
-                        startIcon={<EditIcon />}
-                        onClick={() => { setEditUser(selectedUser); setSelectedUser(null); }}
-                    >
-                        Edit Info
-                    </Button>
-                    <Button
-                        fullWidth
-                        variant="outlined"
-                        startIcon={<AccountBalanceWalletIcon />}
-                        onClick={() => { setRechargeUser(selectedUser); setSelectedUser(null); }}
-                    >
-                        Recharge / Adjust Balance
-                    </Button>
-                    <Button
-                        fullWidth
-                        variant="outlined"
-                        startIcon={<ReceiptLongIcon />}
-                        onClick={() => { setTxUser(selectedUser); setSelectedUser(null); }}
-                    >
-                        View Transactions
-                    </Button>
-                    <Button
-                        fullWidth
-                        variant="outlined"
-                        color="error"
-                        startIcon={<DeleteIcon />}
-                        onClick={() => { setConfirmDeleteUser(selectedUser); setSelectedUser(null); }}
-                    >
-                        Delete User
-                    </Button>
-                </Box>
-            </Dialog>
 
             <EditUserModal
                 open={Boolean(editUser)}
@@ -393,27 +113,11 @@ export default function AdminUsersPage() {
                 user={txUser}
             />
 
-            {/* Delete confirmation dialog */}
-            <Dialog
-                open={Boolean(confirmDeleteUser)}
+            <ConfirmDeleteUserDialog
+                user={confirmDeleteUser}
                 onClose={() => setConfirmDeleteUser(null)}
-                maxWidth="xs"
-                fullWidth
-            >
-                <DialogTitle>Delete user?</DialogTitle>
-                <DialogContent>
-                    <DialogContentText>
-                        Are you sure you want to permanently delete{" "}
-                        <strong>{confirmDeleteUser?.username}</strong>? This action cannot be undone.
-                    </DialogContentText>
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={() => setConfirmDeleteUser(null)}>Cancel</Button>
-                    <Button color="error" variant="contained" onClick={handleDeleteUser}>
-                        Delete
-                    </Button>
-                </DialogActions>
-            </Dialog>
+                onConfirm={handleDeleteUser}
+            />
         </Box>
     );
 }

--- a/app/src/views/AdminUsersPage.smoke.test.jsx
+++ b/app/src/views/AdminUsersPage.smoke.test.jsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const mockUsers = [
+    { id: "u1", username: "alice", name: "Alice", surname: "A", email: "a@x.com", balance: 5, is_admin: true, is_active: true },
+    { id: "u2", username: "bob", name: "Bob", surname: "B", email: "b@x.com", balance: -2, is_admin: false, is_active: true },
+];
+
+vi.mock("../context/AdminContext", () => ({
+    useAdmin: () => ({
+        users: mockUsers,
+        usersLoading: false,
+        updateUser: vi.fn(),
+        adjustBalance: vi.fn(),
+        rechargeBalance: vi.fn(),
+        deleteUser: vi.fn(),
+        refreshAll: vi.fn(),
+    }),
+}));
+
+const { default: AdminUsersPage } = await import("./AdminUsersPage");
+
+describe("AdminUsersPage smoke test", () => {
+    it("renders the user directory without crashing", () => {
+        render(<AdminUsersPage />);
+
+        expect(screen.getAllByText("alice").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("bob").length).toBeGreaterThan(0);
+    });
+});

--- a/app/vitest.config.js
+++ b/app/vitest.config.js
@@ -6,5 +6,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    setupFiles: ['./src/test-setup.js'],
   },
 })


### PR DESCRIPTION
## Summary
(Re-opened against `main` — the original PR #36 targeted `robustness/quick-wins`, which closed this PR automatically when that branch was deleted after merging. Same content, now includes the quick-wins commits since they're already in `main`.)

Deep split of the 4 components flagged as maintainability debt in the earlier audit (657/597/418/399 lines), introducing `src/hooks/` (previously empty) as a real pattern:

- **`AdminStatisticsPage.jsx`** (657 → 314 lines): extracted `StatCard`, `FinanceBreakdownItem`, `StatsTableSkeletonRows`; unified the two near-duplicate charts into one `StatsBarChart` and the two near-duplicate tables into one `StatsBreakdownTable`; moved derived chart/finance data into a `useStatisticsData` hook.
- **`StepSend.jsx`** (597 → 173 lines): the printer-info/files-list/cost-summary cards were each fully reimplemented twice (mobile vs desktop) — now one implementation per card, adapting via an `isMobile` prop. Print-summary derivation moved to `usePrintSummary`, the submit-with-snackbars flow to `useSubmitPrint`.
- **`AdminUsersPage.jsx`** (418 → 123 lines): extracted the user table + mobile action sheet into `UsersTable`, the repeated status-chip pair into `UserStatusChips`, delete-confirmation dialog into its own component.
- **`GroupDetailModal.jsx`** (399 → 70 lines): split the two tabs into `GroupMembersTab`/`GroupPrinterPermitsTab`; factored the 5 near-identical try/catch/loading/refresh handlers into a new `useAsyncAction` hook.

Also wired up `@testing-library/jest-dom` (already a dependency, unused) via a vitest `setupFiles` entry.

## Test plan
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run build` — succeeds
- [x] `npm run test` — 29/29 passing, including:
  - The 3 planned targeted tests: `ErrorBoundary`, `BalanceHeader`, `useAsyncAction`
  - Smoke-render tests for all 4 split pages/modal (in place of manual browser testing, unavailable in this environment) — each renders with mocked data and asserts no crash + expected content
- [ ] Manual: click through the statistics dashboard, print wizard send step (mobile + desktop), admin users page, and group detail modal in a real browser to confirm no visual regression