### PR TITLE
Fix crash when closing the group edit modal

### DIFF
--- a/app/src/components/adminComponents/GroupDetailModal.jsx
+++ b/app/src/components/adminComponents/GroupDetailModal.jsx
@@ -30,7 +30,7 @@ export default function GroupDetailModal({ open, onClose, group, users, printers
     const memberCount = (detail?.members ?? []).length;
     const permitCount = (detail?.printer_permits ?? []).length;
 
-    const content = detailLoading ? (
+    const content = !open || !group ? null : detailLoading ? (
         <Box display="flex" justifyContent="center" py={4}>
             <CircularProgress />
         </Box>

--- a/app/src/components/adminComponents/GroupMembersTab.jsx
+++ b/app/src/components/adminComponents/GroupMembersTab.jsx
@@ -87,7 +87,7 @@ export default function GroupMembersTab({ group, users, detail, refresh }) {
             <ConfirmDialog
                 open={Boolean(removeTarget)}
                 title="Remove member?"
-                message={`Remove @${removeTarget?.username} from "${group.name}"? They will lose access to this group's restricted printers and pricing.`}
+                message={`Remove @${removeTarget?.username} from "${group?.name}"? They will lose access to this group's restricted printers and pricing.`}
                 onClose={() => setRemoveTarget(null)}
                 onConfirm={() => runRemoveMember(removeTarget.id)}
                 loading={removeLoading}


### PR DESCRIPTION
## Summary
- On the admin Groups page, closing the "Manage members & permits" modal for an *existing* group crashed the whole app to the "Something went wrong" error boundary.
- Root cause: `GroupDetailModal`'s tab content was built unconditionally on every render. MUI's `Dialog` keeps its children mounted during the closing transition, and the parent (`AdminGroupsPage`) nulls out the selected group in the same `onClose` handler that flips `open` to false — so the modal re-rendered once more with `group=null` mid-close. `GroupMembersTab`'s `ConfirmDialog` message built a template literal with an unguarded `group.name`, which threw.
- Fix: `GroupDetailModal`'s `content` now short-circuits to `null` when `!open || !group`, so no child ever renders against a null group during the close transition. Also null-checked the remaining unguarded access in `GroupMembersTab` as a second line of defense.

## Test plan
- [x] Verified locally against the local-testing stack (backend+bot+frontend, disposable local Postgres): logged in as `superadmin`, created a group, opened the edit modal, closed it via the Close button 3 times in a row (including switching to the Printer Permits tab before one close) — no crash, no console errors, Groups page stayed usable throughout.
- [ ] CI: `test` + `e2e` required checks (branch protection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Ros9b1NttjHYjsXncT4Rh